### PR TITLE
fix: handle config lock contention in codex-pool

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -140,6 +140,32 @@ Update your `~/.config/opencode/opencode.json`:
 
 ---
 
+## Concurrent Sessions & Storage
+
+<details>
+<summary><b><code>codex-pool</code> reports that plugin configuration is locked</b></summary>
+
+**Symptoms:**
+- A pool mutation reports `config_locked` with `retryable: true` in JSON output.
+- Text output says the plugin configuration is locked by another process and no change was made.
+
+**Cause:** Another OpenCode process is updating `~/.opencode/openai-codex-auth-config.json`. Pool dry-runs and true no-op mutations do not acquire this lock; changes wait for a bounded retry window before returning this signal.
+
+**Solution:** No partial change was applied. Retry the same `codex-pool` action shortly. If contention persists, finish or stop other processes that are actively changing plugin configuration, then retry.
+
+</details>
+
+<details>
+<summary><b><code>Multi-worktree collision detected on account storage</code> warning</b></summary>
+
+This advisory warning means another live process or host is using the same account-storage file. It includes the foreign and local PID, host, and working directory so you can identify the sessions. Reads and writes continue because the worktree lock is intentionally advisory; repeated warnings are throttled to once per minute.
+
+If account rotation or rate-limit state appears stale, close the duplicate session or ensure each worktree resolves to the intended project storage, then restart OpenCode and inspect the account list. Do not delete a lock belonging to a live process.
+
+</details>
+
+---
+
 ## Authentication Issues
 
 <details open>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -149,7 +149,7 @@ Update your `~/.config/opencode/opencode.json`:
 - A pool mutation reports `config_locked` with `retryable: true` in JSON output.
 - Text output says the plugin configuration is locked by another process and no change was made.
 
-**Cause:** Another OpenCode process is updating `~/.opencode/openai-codex-auth-config.json`. Pool dry-runs and true no-op mutations do not acquire this lock; changes wait for a bounded retry window before returning this signal.
+**Cause:** Another OpenCode process is updating `~/.opencode/openai-codex-auth-config.json`. Pool dry-runs do not acquire this lock. Every non-dry mutation, including a possible no-op, waits for the bounded retry window and is revalidated under the lock so its result cannot rely on a stale preview.
 
 **Solution:** No partial change was applied. Retry the same `codex-pool` action shortly. If contention persists, finish or stop other processes that are actively changing plugin configuration, then retry.
 
@@ -158,7 +158,7 @@ Update your `~/.config/opencode/opencode.json`:
 <details>
 <summary><b><code>Multi-worktree collision detected on account storage</code> warning</b></summary>
 
-This advisory warning means another live process or host is using the same account-storage file. It includes the foreign and local PID, host, and working directory so you can identify the sessions. Reads and writes continue because the worktree lock is intentionally advisory; repeated warnings are throttled to once per minute.
+This advisory warning means another live process or host is using the same account-storage file. It includes the foreign and local PID, host, and working directory so you can identify the sessions. Reads and writes continue because the worktree lock is intentionally advisory; repeated warnings are throttled to once per minute for each storage path and foreign lock generation.
 
 If account rotation or rate-limit state appears stale, close the duplicate session or ensure each worktree resolves to the intended project storage, then restart OpenCode and inspect the account list. Do not delete a lock belonging to a live process.
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -179,14 +179,13 @@ export function updateModelAccountPool(
 	options: { dryRun?: boolean; poolMode?: ModelAccountPoolMode } = {},
 ): Promise<ModelAccountPoolMutationResult> {
 	const pending = modelAccountPoolMutationQueue.then(async () => {
-		const preview = await performModelAccountPoolMutation(
-			model,
-			mutation,
-			accountIds,
-			{ ...options, dryRun: true },
-		);
-		if (options.dryRun === true || !preview.changed) {
-			return { ...preview, dryRun: options.dryRun === true };
+		if (options.dryRun === true) {
+			return performModelAccountPoolMutation(
+				model,
+				mutation,
+				accountIds,
+				options,
+			);
 		}
 
 		await fs.mkdir(dirname(CONFIG_PATH), { recursive: true, mode: 0o700 });
@@ -205,7 +204,7 @@ export function updateModelAccountPool(
 				},
 			});
 		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code === "ELOCKED") {
+			if (hasErrorCode(error, "ELOCKED")) {
 				throw new ConfigLockContentionError(CONFIG_PATH, error);
 			}
 			throw error;
@@ -226,6 +225,15 @@ export function updateModelAccountPool(
 		() => undefined,
 	);
 	return pending;
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		error.code === code
+	);
 }
 
 async function performModelAccountPoolMutation(

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -12,6 +12,9 @@ import {
 import { logWarn } from "./logger.js";
 import { stripEffortSuffix } from "./request/helpers/effort-suffix.js";
 import { renameWithWindowsRetry } from "./storage/atomic-write.js";
+import { ConfigLockContentionError } from "./errors.js";
+
+export { ConfigLockContentionError } from "./errors.js";
 import {
 	PluginConfigSchema,
 	getValidationErrors,
@@ -176,19 +179,37 @@ export function updateModelAccountPool(
 	options: { dryRun?: boolean; poolMode?: ModelAccountPoolMode } = {},
 ): Promise<ModelAccountPoolMutationResult> {
 	const pending = modelAccountPoolMutationQueue.then(async () => {
+		const preview = await performModelAccountPoolMutation(
+			model,
+			mutation,
+			accountIds,
+			{ ...options, dryRun: true },
+		);
+		if (options.dryRun === true || !preview.changed) {
+			return { ...preview, dryRun: options.dryRun === true };
+		}
+
 		await fs.mkdir(dirname(CONFIG_PATH), { recursive: true, mode: 0o700 });
-		const release = await lock(CONFIG_PATH, {
-			realpath: false,
-			stale: 10_000,
-			update: 2_000,
-			retries: {
-				retries: 20,
-				factor: 1.2,
-				minTimeout: 25,
-				maxTimeout: 200,
-				randomize: true,
-			},
-		});
+		let release: () => Promise<void>;
+		try {
+			release = await lock(CONFIG_PATH, {
+				realpath: false,
+				stale: 10_000,
+				update: 2_000,
+				retries: {
+					retries: 22,
+					factor: 1.2,
+					minTimeout: 25,
+					maxTimeout: 225,
+					randomize: true,
+				},
+			});
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ELOCKED") {
+				throw new ConfigLockContentionError(CONFIG_PATH, error);
+			}
+			throw error;
+		}
 		try {
 			return await performModelAccountPoolMutation(
 				model,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -11,7 +11,10 @@ import {
 } from "./request/retry-budget.js";
 import { logWarn } from "./logger.js";
 import { stripEffortSuffix } from "./request/helpers/effort-suffix.js";
-import { renameWithWindowsRetry } from "./storage/atomic-write.js";
+import {
+	isWindowsLockError,
+	renameWithWindowsRetry,
+} from "./storage/atomic-write.js";
 import { ConfigLockContentionError } from "./errors.js";
 
 export { ConfigLockContentionError } from "./errors.js";
@@ -195,6 +198,19 @@ export function updateModelAccountPool(
 				realpath: false,
 				stale: 10_000,
 				update: 2_000,
+				// proper-lockfile's default `onCompromised` rethrows from inside an
+				// fs callback. Nothing in this process installs an
+				// `uncaughtException` handler, so a lock that goes stale mid-mutation
+				// (event loop blocked past `stale`, or another process reclaiming the
+				// entry) would take the whole plugin down instead of failing this one
+				// call. The mutation is already in flight and cannot be rolled back,
+				// so the only useful response is to record it; the release below
+				// tolerates the ERELEASED that follows.
+				onCompromised: (error: Error) => {
+					logWarn(
+						`Plugin configuration lock at ${CONFIG_PATH} was compromised mid-mutation: ${error.message}`,
+					);
+				},
 				retries: {
 					retries: 22,
 					factor: 1.2,
@@ -204,7 +220,7 @@ export function updateModelAccountPool(
 				},
 			});
 		} catch (error) {
-			if (hasErrorCode(error, "ELOCKED")) {
+			if (isLockContentionError(error)) {
 				throw new ConfigLockContentionError(CONFIG_PATH, error);
 			}
 			throw error;
@@ -217,7 +233,12 @@ export function updateModelAccountPool(
 				options,
 			);
 		} finally {
-			await release();
+			// A release failure must never replace the mutation's outcome. By this
+			// point the config has already been written, so surfacing ERELEASED (or
+			// a Windows EPERM/EBUSY on the lock directory, which `removeLock`
+			// propagates straight from `rmdir`) would report a fatal lock error for
+			// a change that actually landed - the exact symptom this fix removes.
+			await releaseLockQuietly(release);
 		}
 	});
 	modelAccountPoolMutationQueue = pending.then(
@@ -234,6 +255,40 @@ function hasErrorCode(error: unknown, code: string): boolean {
 		"code" in error &&
 		error.code === code
 	);
+}
+
+/**
+ * True when a lock acquisition failure means "another process holds it", as
+ * opposed to a genuine environment fault the caller must see.
+ *
+ * proper-lockfile forwards raw fs errors from the lock directory's
+ * `mkdir`/`stat`/`rmdir` straight into its retry loop, so the error that
+ * finally escapes (`operation.mainError()`) is not always ELOCKED. On Windows a
+ * lock directory held open by another process - or by an antivirus scanner or
+ * the search indexer - surfaces as EPERM/EBUSY rather than EEXIST, the same
+ * class `renameWithWindowsRetry` already tolerates one layer down. Those codes
+ * count as contention only on win32; on POSIX an EPERM really is a permission
+ * problem and has to stay fatal.
+ */
+function isLockContentionError(error: unknown): boolean {
+	if (hasErrorCode(error, "ELOCKED")) return true;
+	return process.platform === "win32" && isWindowsLockError(error);
+}
+
+/** Release a config lock, downgrading any failure to a warning. */
+async function releaseLockQuietly(release: () => Promise<void>): Promise<void> {
+	try {
+		await release();
+	} catch (error) {
+		// Losing the lock directory is recoverable on its own: `stale` reclaims a
+		// leftover entry within 10s, and the mutation it guarded is already
+		// durable on disk.
+		logWarn(
+			`Failed to release plugin configuration lock at ${CONFIG_PATH}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
 }
 
 async function performModelAccountPoolMutation(

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -38,6 +38,7 @@ export const ErrorCode = {
 	PROMPT_ERROR: "CODEX_PROMPT_ERROR",
 	REQUEST_ERROR: "CODEX_REQUEST_ERROR",
 	CONFIG_ERROR: "CODEX_CONFIG_ERROR",
+	CONFIG_LOCK_CONTENTION: "CODEX_CONFIG_LOCK_CONTENTION",
 } as const;
 
 export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];
@@ -309,12 +310,26 @@ export class RequestError extends CodexError {
  * input, bad format flags, missing required options).
  */
 export class ConfigError extends CodexError {
-	override readonly name = "ConfigError";
+	override readonly name: string = "ConfigError";
 
 	constructor(message: string, options?: CodexErrorOptions) {
 		super(message, {
 			...options,
 			code: options?.code ?? ErrorCode.CONFIG_ERROR,
 		});
+	}
+}
+
+export class ConfigLockContentionError extends ConfigError {
+	override readonly name = "ConfigLockContentionError";
+	readonly path: string;
+
+	constructor(path: string, cause?: unknown) {
+		super(`Plugin configuration at ${path} is locked by another process.`, {
+			code: ErrorCode.CONFIG_LOCK_CONTENTION,
+			cause,
+			context: { path },
+		});
+		this.path = path;
 	}
 }

--- a/lib/storage/atomic-write.ts
+++ b/lib/storage/atomic-write.ts
@@ -15,7 +15,7 @@ export const WINDOWS_RENAME_RETRY_ATTEMPTS = 5;
 export const WINDOWS_RENAME_RETRY_BASE_DELAY_MS = 10;
 export const PRE_IMPORT_BACKUP_WRITE_TIMEOUT_MS = 3_000;
 
-function isWindowsLockError(error: unknown): error is NodeJS.ErrnoException {
+export function isWindowsLockError(error: unknown): error is NodeJS.ErrnoException {
   const code = (error as NodeJS.ErrnoException)?.code;
   return code === "EPERM" || code === "EBUSY";
 }

--- a/lib/storage/load-save.ts
+++ b/lib/storage/load-save.ts
@@ -49,10 +49,44 @@ import os from "node:os";
 
 const log = createLogger("storage");
 const COLLISION_WARNING_THROTTLE_MS = 60_000;
-let lastCollisionWarningAt: number | undefined;
+const COLLISION_WARNING_THROTTLE_MAX_ENTRIES = 128;
+const collisionWarningTimes = new Map<string, number>();
 
 export function __resetCollisionWarningThrottleForTests(): void {
-  lastCollisionWarningAt = undefined;
+  collisionWarningTimes.clear();
+}
+
+function shouldWarnForCollision(
+  storagePath: string,
+  foreign: { hostname: string; pid: number; startedAt: string },
+): boolean {
+  const now = Date.now();
+  for (const [key, warnedAt] of collisionWarningTimes) {
+    if (
+      now < warnedAt ||
+      now - warnedAt >= COLLISION_WARNING_THROTTLE_MS
+    ) {
+      collisionWarningTimes.delete(key);
+    }
+  }
+
+  const key = JSON.stringify([
+    storagePath,
+    foreign.hostname,
+    foreign.pid,
+    foreign.startedAt,
+  ]);
+  if (collisionWarningTimes.has(key)) return false;
+
+  collisionWarningTimes.set(key, now);
+  while (
+    collisionWarningTimes.size > COLLISION_WARNING_THROTTLE_MAX_ENTRIES
+  ) {
+    const oldestKey = collisionWarningTimes.keys().next().value;
+    if (oldestKey === undefined) break;
+    collisionWarningTimes.delete(oldestKey);
+  }
+  return true;
 }
 
 /**
@@ -85,12 +119,7 @@ async function checkWorktreeLockForCurrentStorage(
   try {
     const result = await acquireOrDetectLock(path);
     if (!result.acquired && result.foreign) {
-      const now = Date.now();
-      if (
-        lastCollisionWarningAt === undefined ||
-        now - lastCollisionWarningAt >= COLLISION_WARNING_THROTTLE_MS
-      ) {
-        lastCollisionWarningAt = now;
+      if (shouldWarnForCollision(path, result.foreign)) {
         log.warn("Multi-worktree collision detected on account storage", {
           operation,
           storagePath: path,

--- a/lib/storage/load-save.ts
+++ b/lib/storage/load-save.ts
@@ -48,6 +48,12 @@ import {
 import os from "node:os";
 
 const log = createLogger("storage");
+const COLLISION_WARNING_THROTTLE_MS = 60_000;
+let lastCollisionWarningAt: number | undefined;
+
+export function __resetCollisionWarningThrottleForTests(): void {
+  lastCollisionWarningAt = undefined;
+}
 
 /**
  * Probes the worktree lock for the currently active storage path and surfaces
@@ -79,17 +85,24 @@ async function checkWorktreeLockForCurrentStorage(
   try {
     const result = await acquireOrDetectLock(path);
     if (!result.acquired && result.foreign) {
-      log.warn("Multi-worktree collision detected on account storage", {
-        operation,
-        storagePath: path,
-        foreignPid: result.foreign.pid,
-        foreignHost: result.foreign.hostname,
-        foreignCwd: result.foreign.cwd,
-        foreignLastActive: result.foreign.lastActive,
-        ourPid: process.pid,
-        ourHost: os.hostname(),
-        ourCwd: process.cwd(),
-      });
+      const now = Date.now();
+      if (
+        lastCollisionWarningAt === undefined ||
+        now - lastCollisionWarningAt >= COLLISION_WARNING_THROTTLE_MS
+      ) {
+        lastCollisionWarningAt = now;
+        log.warn("Multi-worktree collision detected on account storage", {
+          operation,
+          storagePath: path,
+          foreignPid: result.foreign.pid,
+          foreignHost: result.foreign.hostname,
+          foreignCwd: result.foreign.cwd,
+          foreignLastActive: result.foreign.lastActive,
+          ourPid: process.pid,
+          ourHost: os.hostname(),
+          ourCwd: process.cwd(),
+        });
+      }
     }
   } catch (error) {
     log.debug("Worktree lock probe failed", {

--- a/lib/tools/codex-pool.ts
+++ b/lib/tools/codex-pool.ts
@@ -2,12 +2,15 @@
 
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
 import {
+	ConfigLockContentionError,
 	getModelAccountPoolMode,
 	loadPluginConfig,
 	type ModelAccountPoolMode,
+	type ModelAccountPoolMutationResult,
 	updateModelAccountPool,
 	type ModelAccountPoolMutation,
 } from "../config.js";
+import { logWarn } from "../logger.js";
 import { normalizeToolOutputFormat, renderJsonOutput } from "../runtime.js";
 import { loadAccounts, type AccountStorageV3 } from "../storage.js";
 import type { ToolContext } from "./index.js";
@@ -247,10 +250,34 @@ export function createCodexPoolTool(ctx: ToolContext): ToolDefinition {
 				action === "clear" || action === "set-mode"
 					? []
 					: resolveAccountIds(storage, args.accounts);
-			const result = await updateModelAccountPool(model, action, accountIds, {
-				dryRun: args.dryRun,
-				poolMode,
-			});
+			let result: ModelAccountPoolMutationResult;
+			try {
+				result = await updateModelAccountPool(model, action, accountIds, {
+					dryRun: args.dryRun,
+					poolMode,
+				});
+			} catch (error) {
+				if (!(error instanceof ConfigLockContentionError)) throw error;
+
+				const message =
+					"The plugin configuration is locked by another process. No change was made — retry shortly.";
+				logWarn("codex-pool could not acquire the plugin configuration lock", {
+					action,
+					model,
+				});
+				if (format === "json") {
+					return renderJsonOutput({
+						action,
+						model,
+						changed: false,
+						applied: false,
+						error: "config_locked",
+						retryable: true,
+						message,
+					});
+				}
+				return `Could not update the account pool for ${model}: ${message}`;
+			}
 			const pool = buildPoolSnapshot(
 				result.model,
 				result.accountIds,

--- a/test/config-lock-contention.test.ts
+++ b/test/config-lock-contention.test.ts
@@ -1,0 +1,53 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { promises as fs } from "node:fs";
+
+const { lockMock } = vi.hoisted(() => ({ lockMock: vi.fn() }));
+const testHome = vi.hoisted(
+	() => `/tmp/oc-codex-config-lock-contention-${process.pid}`,
+);
+
+vi.mock("proper-lockfile", () => ({ lock: lockMock }));
+vi.mock("node:os", async () => {
+	const actual = await vi.importActual<typeof import("node:os")>("node:os");
+	return { ...actual, homedir: () => testHome };
+});
+
+import {
+	ConfigLockContentionError,
+	updateModelAccountPool,
+} from "../lib/config.js";
+
+describe("model account pool config lock contention", () => {
+	beforeEach(async () => {
+		lockMock.mockReset();
+		await fs.rm(testHome, { recursive: true, force: true });
+	});
+
+	afterAll(async () => {
+		await fs.rm(testHome, { recursive: true, force: true });
+	});
+
+	it("classifies only exhausted proper-lockfile acquisition", async () => {
+		const cause = Object.assign(new Error("already held"), { code: "ELOCKED" });
+		lockMock.mockRejectedValue(cause);
+
+		const pending = updateModelAccountPool("model", "set", ["one"]);
+
+		await expect(pending).rejects.toMatchObject({
+			name: "ConfigLockContentionError",
+			code: "CODEX_CONFIG_LOCK_CONTENTION",
+			path: `${testHome}/.opencode/openai-codex-auth-config.json`,
+			cause,
+		});
+		await expect(pending).rejects.toBeInstanceOf(ConfigLockContentionError);
+	});
+
+	it("preserves non-contention lock acquisition failures", async () => {
+		const cause = Object.assign(new Error("permission denied"), { code: "EACCES" });
+		lockMock.mockRejectedValue(cause);
+
+		await expect(
+			updateModelAccountPool("model", "set", ["one"]),
+		).rejects.toBe(cause);
+	});
+});

--- a/test/config-lock-contention.test.ts
+++ b/test/config-lock-contention.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { promises as fs } from "node:fs";
+import { dirname, join } from "node:path";
 
 const { lockMock } = vi.hoisted(() => ({ lockMock: vi.fn() }));
 const testHome = vi.hoisted(
@@ -18,6 +19,12 @@ import {
 } from "../lib/config.js";
 
 describe("model account pool config lock contention", () => {
+	const configPath = join(
+		testHome,
+		".opencode",
+		"openai-codex-auth-config.json",
+	);
+
 	beforeEach(async () => {
 		lockMock.mockReset();
 		await fs.rm(testHome, { recursive: true, force: true });
@@ -49,5 +56,40 @@ describe("model account pool config lock contention", () => {
 		await expect(
 			updateModelAccountPool("model", "set", ["one"]),
 		).rejects.toBe(cause);
+	});
+
+	it("revalidates a non-dry no-op after acquiring the lock", async () => {
+		await fs.mkdir(dirname(configPath), { recursive: true });
+		await fs.writeFile(
+			configPath,
+			JSON.stringify({ modelAccountPools: { model: ["one"] } }),
+			"utf8",
+		);
+		lockMock.mockImplementationOnce(async () => {
+			await fs.writeFile(
+				configPath,
+				JSON.stringify({ modelAccountPools: { model: [] } }),
+				"utf8",
+			);
+			return async () => {};
+		});
+
+		const result = await updateModelAccountPool("model", "set", ["one"]);
+		const persisted = JSON.parse(await fs.readFile(configPath, "utf8")) as {
+			modelAccountPools: Record<string, string[]>;
+		};
+
+		expect(lockMock).toHaveBeenCalledTimes(1);
+		expect(result.changed).toBe(true);
+		expect(result.previousAccountIds).toEqual([]);
+		expect(persisted.modelAccountPools.model).toEqual(["one"]);
+	});
+
+	it("preserves malformed lock acquisition rejections", async () => {
+		lockMock.mockRejectedValue(null);
+
+		await expect(
+			updateModelAccountPool("model", "set", ["one"]),
+		).rejects.toBe(null);
 	});
 });

--- a/test/config-lock-contention.test.ts
+++ b/test/config-lock-contention.test.ts
@@ -1,4 +1,12 @@
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 import { promises as fs } from "node:fs";
 import { dirname, join } from "node:path";
 
@@ -25,9 +33,26 @@ describe("model account pool config lock contention", () => {
 		"openai-codex-auth-config.json",
 	);
 
+	const realPlatform = process.platform;
+
+	/**
+	 * The Windows branch of the contention classifier has to be exercised from
+	 * Linux CI too, so the platform is stubbed rather than the test skipped.
+	 */
+	function stubPlatform(platform: NodeJS.Platform): void {
+		Object.defineProperty(process, "platform", {
+			value: platform,
+			configurable: true,
+		});
+	}
+
 	beforeEach(async () => {
 		lockMock.mockReset();
 		await fs.rm(testHome, { recursive: true, force: true });
+	});
+
+	afterEach(() => {
+		stubPlatform(realPlatform);
 	});
 
 	afterAll(async () => {
@@ -43,7 +68,7 @@ describe("model account pool config lock contention", () => {
 		await expect(pending).rejects.toMatchObject({
 			name: "ConfigLockContentionError",
 			code: "CODEX_CONFIG_LOCK_CONTENTION",
-			path: `${testHome}/.opencode/openai-codex-auth-config.json`,
+			path: configPath,
 			cause,
 		});
 		await expect(pending).rejects.toBeInstanceOf(ConfigLockContentionError);
@@ -83,6 +108,87 @@ describe("model account pool config lock contention", () => {
 		expect(result.changed).toBe(true);
 		expect(result.previousAccountIds).toEqual([]);
 		expect(persisted.modelAccountPools.model).toEqual(["one"]);
+	});
+
+	it("keeps a successful mutation when releasing the lock fails", async () => {
+		// proper-lockfile rejects release() with ERELEASED when the lock was
+		// compromised mid-mutation, and removeLock propagates any non-ENOENT
+		// rmdir error. Before the fix that rejection escaped from the finally
+		// block and replaced the return value, so a change that had already
+		// reached disk was reported as a fatal lock error.
+		const releaseError = Object.assign(new Error("lock is already released"), {
+			code: "ERELEASED",
+		});
+		lockMock.mockResolvedValueOnce(async () => {
+			throw releaseError;
+		});
+
+		const result = await updateModelAccountPool("model", "set", ["one"]);
+		const persisted = JSON.parse(await fs.readFile(configPath, "utf8")) as {
+			modelAccountPools: Record<string, string[]>;
+		};
+
+		expect(result.changed).toBe(true);
+		expect(persisted.modelAccountPools.model).toEqual(["one"]);
+	});
+
+	it("installs an onCompromised handler that cannot kill the process", async () => {
+		// The proper-lockfile default rethrows from inside an fs callback, and
+		// nothing in this process installs an uncaughtException handler.
+		lockMock.mockResolvedValueOnce(async () => {});
+
+		await updateModelAccountPool("model", "set", ["one"]);
+
+		const options = lockMock.mock.calls[0]?.[1] as {
+			onCompromised?: (error: Error) => void;
+		};
+		expect(typeof options?.onCompromised).toBe("function");
+		expect(() =>
+			options.onCompromised?.(
+				Object.assign(new Error("lock compromised"), {
+					code: "ECOMPROMISED",
+				}),
+			),
+		).not.toThrow();
+	});
+
+	it("classifies Windows lock-directory failures as contention", async () => {
+		// On win32 a lock directory held open by another process (or by an
+		// antivirus scanner or the indexer) surfaces as EPERM/EBUSY, never
+		// EEXIST, so operation.mainError() is not ELOCKED and the degrade path
+		// used to be skipped entirely.
+		stubPlatform("win32");
+		const cause = Object.assign(new Error("operation not permitted"), {
+			code: "EPERM",
+		});
+		lockMock.mockRejectedValue(cause);
+
+		await expect(
+			updateModelAccountPool("model", "set", ["one"]),
+		).rejects.toBeInstanceOf(ConfigLockContentionError);
+	});
+
+	it("keeps EPERM fatal off Windows", async () => {
+		stubPlatform("linux");
+		const cause = Object.assign(new Error("operation not permitted"), {
+			code: "EPERM",
+		});
+		lockMock.mockRejectedValue(cause);
+
+		await expect(updateModelAccountPool("model", "set", ["one"])).rejects.toBe(
+			cause,
+		);
+	});
+
+	it("previews without acquiring the configuration lock", async () => {
+		// The one behaviour this branch actually changes for non-error callers:
+		// a dry run no longer contends for the config lock at all.
+		const result = await updateModelAccountPool("model", "set", ["one"], {
+			dryRun: true,
+		});
+
+		expect(lockMock).not.toHaveBeenCalled();
+		expect(result).toMatchObject({ dryRun: true, changed: true });
 	});
 
 	it("preserves malformed lock acquisition rejections", async () => {

--- a/test/model-pool-config.test.ts
+++ b/test/model-pool-config.test.ts
@@ -170,18 +170,12 @@ describe("model account pool config mutation", () => {
 		await expect(fs.stat(configPath)).rejects.toMatchObject({ code: "ENOENT" });
 	});
 
-	it("does not rewrite an unchanged pool", async () => {
+	it("does not rewrite a pool that is unchanged under the lock", async () => {
 		const original = `${JSON.stringify({
 			modelAccountPools: { model: ["one"] },
 		})}\n\n`;
 		await fs.writeFile(configPath, original);
-		const releaseForeignLock = await lock(configPath, { realpath: false });
-		let result: Awaited<ReturnType<typeof updateModelAccountPool>>;
-		try {
-			result = await updateModelAccountPool("model", "set", ["one"]);
-		} finally {
-			await releaseForeignLock();
-		}
+		const result = await updateModelAccountPool("model", "set", ["one"]);
 
 		expect(result.changed).toBe(false);
 		expect(await fs.readFile(configPath, "utf-8")).toBe(original);

--- a/test/model-pool-config.test.ts
+++ b/test/model-pool-config.test.ts
@@ -152,9 +152,15 @@ describe("model account pool config mutation", () => {
 	});
 
 	it("previews a change without creating or modifying the config file", async () => {
-		const result = await updateModelAccountPool("model", "set", ["one"], {
-			dryRun: true,
-		});
+		const releaseForeignLock = await lock(configPath, { realpath: false });
+		let result: Awaited<ReturnType<typeof updateModelAccountPool>>;
+		try {
+			result = await updateModelAccountPool("model", "set", ["one"], {
+				dryRun: true,
+			});
+		} finally {
+			await releaseForeignLock();
+		}
 
 		expect(result).toMatchObject({
 			accountIds: ["one"],
@@ -169,8 +175,13 @@ describe("model account pool config mutation", () => {
 			modelAccountPools: { model: ["one"] },
 		})}\n\n`;
 		await fs.writeFile(configPath, original);
-
-		const result = await updateModelAccountPool("model", "set", ["one"]);
+		const releaseForeignLock = await lock(configPath, { realpath: false });
+		let result: Awaited<ReturnType<typeof updateModelAccountPool>>;
+		try {
+			result = await updateModelAccountPool("model", "set", ["one"]);
+		} finally {
+			await releaseForeignLock();
+		}
 
 		expect(result.changed).toBe(false);
 		expect(await fs.readFile(configPath, "utf-8")).toBe(original);

--- a/test/model-pool-config.test.ts
+++ b/test/model-pool-config.test.ts
@@ -12,7 +12,10 @@ vi.mock("node:os", async () => {
 	return { ...actual, homedir: () => testHome };
 });
 
-import { updateModelAccountPool } from "../lib/config.js";
+import {
+	ConfigLockContentionError,
+	updateModelAccountPool,
+} from "../lib/config.js";
 
 const configDir = join(testHome, ".opencode");
 const configPath = join(configDir, "openai-codex-auth-config.json");
@@ -150,6 +153,34 @@ describe("model account pool config mutation", () => {
 			modelAccountPools: { model: ["one", "external", "two"] },
 		});
 	});
+
+	it(
+		"degrades to a contention error when a foreign lock outlasts the retry budget",
+		async () => {
+			// Deliberately unmocked. Every other contention test stubs
+			// proper-lockfile, so nothing else verifies the assumption the whole
+			// degrade path rests on: that an exhausted retry budget really does
+			// surface as code "ELOCKED".
+			await fs.writeFile(
+				configPath,
+				JSON.stringify({ modelAccountPools: { model: ["one"] } }),
+			);
+			const releaseForeignLock = await lock(configPath, { realpath: false });
+			try {
+				await expect(
+					updateModelAccountPool("model", "add", ["two"]),
+				).rejects.toBeInstanceOf(ConfigLockContentionError);
+			} finally {
+				await releaseForeignLock();
+			}
+
+			// The contended call must be a no-op, not a partial write.
+			expect(await readConfig()).toMatchObject({
+				modelAccountPools: { model: ["one"] },
+			});
+		},
+		20_000,
+	);
 
 	it("previews a change without creating or modifying the config file", async () => {
 		const releaseForeignLock = await lock(configPath, { realpath: false });

--- a/test/storage-collision-warning.test.ts
+++ b/test/storage-collision-warning.test.ts
@@ -65,4 +65,63 @@ describe("account storage collision warning throttle", () => {
 
 		expect(warnMock).toHaveBeenCalledTimes(2);
 	});
+
+	it("warns separately for distinct storage paths", async () => {
+		await loadAccounts();
+		setStoragePathDirect(
+			"/tmp/oc-codex-collision-warning-other/accounts.json",
+		);
+
+		await loadAccounts();
+
+		expect(warnMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("warns separately for a new foreign lock generation", async () => {
+		await loadAccounts();
+		acquireOrDetectLockMock.mockResolvedValue({
+			acquired: false,
+			foreign: {
+				pid: 1234,
+				hostname: "other-host",
+				cwd: "/tmp/other-worktree",
+				startedAt: new Date(1).toISOString(),
+				lastActive: new Date(1).toISOString(),
+			},
+		});
+
+		await loadAccounts();
+
+		expect(warnMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("bounds remembered collision identities", async () => {
+		for (let pid = 1; pid <= 129; pid += 1) {
+			acquireOrDetectLockMock.mockResolvedValueOnce({
+				acquired: false,
+				foreign: {
+					pid,
+					hostname: "other-host",
+					cwd: "/tmp/other-worktree",
+					startedAt: new Date(0).toISOString(),
+					lastActive: new Date(0).toISOString(),
+				},
+			});
+			await loadAccounts();
+		}
+		acquireOrDetectLockMock.mockResolvedValueOnce({
+			acquired: false,
+			foreign: {
+				pid: 1,
+				hostname: "other-host",
+				cwd: "/tmp/other-worktree",
+				startedAt: new Date(0).toISOString(),
+				lastActive: new Date(0).toISOString(),
+			},
+		});
+
+		await loadAccounts();
+
+		expect(warnMock).toHaveBeenCalledTimes(130);
+	});
 });

--- a/test/storage-collision-warning.test.ts
+++ b/test/storage-collision-warning.test.ts
@@ -29,6 +29,18 @@ import {
 } from "../lib/storage/load-save.js";
 import { setStoragePathDirect } from "../lib/storage/state.js";
 
+const COLLISION_MESSAGE = "Multi-worktree collision detected on account storage";
+
+/**
+ * loadAccounts() warns from several unrelated sites (schema validation, global
+ * fallback load failures). Counting every warn would fail this suite the moment
+ * any of them fires, so only the collision warning is counted.
+ */
+function collisionWarnCount(): number {
+	return warnMock.mock.calls.filter((call) => call[0] === COLLISION_MESSAGE)
+		.length;
+}
+
 describe("account storage collision warning throttle", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
@@ -58,12 +70,12 @@ describe("account storage collision warning throttle", () => {
 		await loadAccounts();
 		await loadAccounts();
 
-		expect(warnMock).toHaveBeenCalledTimes(1);
+		expect(collisionWarnCount()).toBe(1);
 
 		vi.advanceTimersByTime(60_000);
 		await loadAccounts();
 
-		expect(warnMock).toHaveBeenCalledTimes(2);
+		expect(collisionWarnCount()).toBe(2);
 	});
 
 	it("warns separately for distinct storage paths", async () => {
@@ -74,7 +86,7 @@ describe("account storage collision warning throttle", () => {
 
 		await loadAccounts();
 
-		expect(warnMock).toHaveBeenCalledTimes(2);
+		expect(collisionWarnCount()).toBe(2);
 	});
 
 	it("warns separately for a new foreign lock generation", async () => {
@@ -92,7 +104,7 @@ describe("account storage collision warning throttle", () => {
 
 		await loadAccounts();
 
-		expect(warnMock).toHaveBeenCalledTimes(2);
+		expect(collisionWarnCount()).toBe(2);
 	});
 
 	it("bounds remembered collision identities", async () => {
@@ -122,6 +134,6 @@ describe("account storage collision warning throttle", () => {
 
 		await loadAccounts();
 
-		expect(warnMock).toHaveBeenCalledTimes(130);
+		expect(collisionWarnCount()).toBe(130);
 	});
 });

--- a/test/storage-collision-warning.test.ts
+++ b/test/storage-collision-warning.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { acquireOrDetectLockMock, warnMock } = vi.hoisted(() => ({
+	acquireOrDetectLockMock: vi.fn(),
+	warnMock: vi.fn(),
+}));
+
+vi.mock("../lib/logger.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/logger.js")>();
+	return {
+		...actual,
+		createLogger: () => ({
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: warnMock,
+			error: vi.fn(),
+			time: vi.fn(),
+			timeEnd: vi.fn(),
+		}),
+	};
+});
+vi.mock("../lib/storage/worktree-lock.js", () => ({
+	acquireOrDetectLock: acquireOrDetectLockMock,
+}));
+
+import {
+	__resetCollisionWarningThrottleForTests,
+	loadAccounts,
+} from "../lib/storage/load-save.js";
+import { setStoragePathDirect } from "../lib/storage/state.js";
+
+describe("account storage collision warning throttle", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+		warnMock.mockReset();
+		acquireOrDetectLockMock.mockReset();
+		acquireOrDetectLockMock.mockResolvedValue({
+			acquired: false,
+			foreign: {
+				pid: 1234,
+				hostname: "other-host",
+				cwd: "/tmp/other-worktree",
+				startedAt: new Date(0).toISOString(),
+				lastActive: new Date(0).toISOString(),
+			},
+		});
+		setStoragePathDirect("/tmp/oc-codex-collision-warning/accounts.json");
+		__resetCollisionWarningThrottleForTests();
+	});
+
+	afterEach(() => {
+		setStoragePathDirect(null);
+		vi.useRealTimers();
+	});
+
+	it("warns once per throttle window", async () => {
+		await loadAccounts();
+		await loadAccounts();
+
+		expect(warnMock).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(60_000);
+		await loadAccounts();
+
+		expect(warnMock).toHaveBeenCalledTimes(2);
+	});
+});

--- a/test/tools-codex-pool.test.ts
+++ b/test/tools-codex-pool.test.ts
@@ -8,15 +8,23 @@ vi.mock("../lib/storage.js", () => ({
 	loadAccounts: vi.fn(),
 }));
 
-vi.mock("../lib/config.js", () => ({
-	getModelAccountPoolMode: vi.fn((config, model) =>
-		config.modelAccountPoolModes?.[model] ?? "preferred",
-	),
-	loadPluginConfig: vi.fn(),
-	updateModelAccountPool: vi.fn(),
-}));
+vi.mock("../lib/config.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/config.js")>();
+	return {
+		...actual,
+		getModelAccountPoolMode: vi.fn((config, model) =>
+			config.modelAccountPoolModes?.[model] ?? "preferred",
+		),
+		loadPluginConfig: vi.fn(),
+		updateModelAccountPool: vi.fn(),
+	};
+});
 
-import { loadPluginConfig, updateModelAccountPool } from "../lib/config.js";
+import {
+	ConfigLockContentionError,
+	loadPluginConfig,
+	updateModelAccountPool,
+} from "../lib/config.js";
 import { loadAccounts } from "../lib/storage.js";
 
 const storage: AccountStorageV3 = {
@@ -54,7 +62,10 @@ function buildCtx(): ToolContext {
 				? { accountId: options.account?.accountId ?? null }
 				: {}),
 		}),
-	} as unknown as ToolContext;
+	} satisfies Pick<
+		ToolContext,
+		"resolveMaskEmail" | "formatCommandAccountLabel" | "buildJsonAccountIdentity"
+	> as unknown as ToolContext;
 }
 
 describe("codex-pool tool", () => {
@@ -249,5 +260,56 @@ describe("codex-pool tool", () => {
 				{} as never,
 			),
 		).rejects.toThrow("has no stable account ID");
+	});
+
+	it("returns retry guidance when configuration lock acquisition is exhausted", async () => {
+		vi.mocked(updateModelAccountPool).mockRejectedValue(
+			new ConfigLockContentionError("/tmp/config.json"),
+		);
+
+		const output = await createCodexPoolTool(buildCtx()).execute(
+			{ action: "set", model: "gpt-5.6-sol", accounts: [1] },
+			{} as never,
+		);
+
+		expect(output).toContain("locked by another process");
+		expect(output).toContain("No change was made");
+	});
+
+	it("returns structured retryable lock contention in JSON", async () => {
+		vi.mocked(updateModelAccountPool).mockRejectedValue(
+			new ConfigLockContentionError("/tmp/config.json"),
+		);
+
+		const output = await createCodexPoolTool(buildCtx()).execute(
+			{
+				action: "set",
+				model: "gpt-5.6-sol",
+				accounts: [1],
+				format: "json",
+			},
+			{} as never,
+		);
+		const parsed = JSON.parse(output as string) as Record<string, unknown>;
+
+		expect(parsed).toMatchObject({
+			action: "set",
+			model: "gpt-5.6-sol",
+			changed: false,
+			applied: false,
+			error: "config_locked",
+			retryable: true,
+		});
+	});
+
+	it("rethrows non-contention persistence failures", async () => {
+		vi.mocked(updateModelAccountPool).mockRejectedValue(new Error("disk failed"));
+
+		await expect(
+			createCodexPoolTool(buildCtx()).execute(
+				{ action: "set", model: "gpt-5.6-sol", accounts: [1] },
+				{} as never,
+			),
+		).rejects.toThrow("disk failed");
 	});
 });


### PR DESCRIPTION
## Summary

- Avoid acquiring the cross-process config lock for dry-run and true no-op model-pool mutations, while re-reading and recomputing changed writes under the lock.
- Classify exhausted proper-lockfile contention as a typed plugin error and degrade it at the codex-pool tool boundary into a nonfatal, retryable result.
- Throttle repeated multi-worktree collision warnings and document both concurrency signals.

This prevents parallel codex-pool subagents from aborting on raw ELOCKED errors while preserving existing successful mutation output and genuine error propagation.

Fixes #224

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (117 files, 2939 tests)
- [ ] Not applicable
- [x] `npm run typecheck`
- [x] Focused contention regression suite (23 tests)
- [x] Real-filesystem proper-lockfile QA against the built and globally installed package

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue: #224
- Related context: #200 introduced model pools/proper-lockfile; #130 introduced the advisory worktree collision signal.
- True multi-process stress testing remains follow-up work; deterministic lock exhaustion, held-lock fast paths, tool degradation, and warning throttling are covered by regression tests and real-filesystem QA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of configuration-file lock conflicts during account-pool updates, including Windows-specific contention cases.
  - Added retryable text and JSON responses when an update cannot proceed because the configuration is locked.
  - Improved lock retries and handling of lock-release failures.
  - Reduced repeated multi-worktree storage collision warnings by throttling them to once per minute.

- **Documentation**
  - Added troubleshooting guidance for concurrent sessions, configuration locks, retries, and multi-worktree collisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

the pr fixes both previously reported concurrency issues.

- non-dry pool mutations now acquire the configuration lock and recompute against the locked state.
- collision warnings are throttled by storage path, foreign owner, and lock generation.
- contention becomes a typed, retryable tool result, with windows filesystem lock errors handled separately.
- focused vitest coverage now exercises stale-preview revalidation, distinct collision paths and generations, contention output, and windows lock classification.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge because both previously reported concurrency failures are fixed.

no blocking failure remains from the prior stale-preview or global collision-throttle findings.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/config.ts | non-dry mutations are re-read under the cross-process lock, and windows contention is converted to a typed error. |
| lib/storage/load-save.ts | collision-warning throttling now distinguishes storage paths, foreign owners, and lock generations. |
| lib/tools/codex-pool.ts | configuration-lock contention is degraded into a nonfatal retryable response while unrelated failures still propagate. |
| test/config-lock-contention.test.ts | vitest coverage exercises contention classification, locked revalidation, release handling, dry runs, and windows filesystem errors. |
| test/storage-collision-warning.test.ts | vitest coverage verifies throttle windows, distinct paths, new lock generations, and bounded throttle state. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Tool as codex-pool
  participant Queue as mutation queue
  participant Lock as config lock
  participant Config as config file
  Tool->>Queue: submit non-dry mutation
  Queue->>Lock: acquire with bounded retries
  alt lock acquired
    Lock-->>Queue: release callback
    Queue->>Config: reread current configuration
    Queue->>Config: atomically write changed state
    Queue->>Lock: release
    Queue-->>Tool: mutation result
  else contention exhausted
    Lock-->>Queue: lock error
    Queue-->>Tool: typed retryable contention
  end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(config): harden config lock release ..."](https://github.com/ndycode/oc-codex-multi-auth/commit/8e3126decbdebce08a1eacedaf48e1ffe9cca1d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51646287)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Config, Schemas, and Shared Primitives](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/config-schemas.md)
- Knowledge Base — [Account Storage Layer](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/storage.md)
- Knowledge Base — [Tools and CLI](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/tools-cli.md)
</details>

<!-- /greptile_comment -->