### PR TITLE
fix(auth): bind each login to its own workspace quota pool

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -257,6 +257,47 @@ Failed to access Codex API
 </details>
 
 <details>
+<summary><b>Two workspace subscriptions report the same plan and quota</b></summary>
+
+**Symptoms:**
+
+- One ChatGPT login (one email / Apple ID) holding **two workspace
+  subscriptions** - for example Team and Plus.
+- `codex-limits` reports the same plan and the same percentage for every entry.
+- `codex-switch` to the other account keeps draining the same pool.
+- Logging in again under the other workspace appears to overwrite every entry.
+
+**Cause:** The OAuth flow requests `id_token_add_organizations=true`, so the
+id_token lists every organization the login belongs to. Releases before this
+fix persisted one account entry per organization, but all of those entries
+shared the login's single OAuth token. The Codex backend meters quota by the
+`chatgpt-account-id` header and ignores organization ids, so an entry whose id
+was an organization id silently fell back to the token's default subscription -
+N entries, one pool.
+
+Each workspace subscription is a distinct ChatGPT account with its own
+`chatgpt_account_id` claim, so separate tokens are what produce separate quotas.
+
+**Solutions:**
+
+1. Upgrade to a release containing this fix. One `opencode auth login` now
+   persists exactly one account, bound to the token's ChatGPT account id and
+   labelled with the workspace you selected.
+2. Log in once per workspace: run `opencode auth login`, pick the first
+   workspace, then run it again and pick the second. Each login appends a
+   separate account carrying its own token, so `codex-limits` reports the two
+   subscriptions independently.
+3. **Existing entries are not rewritten.** Accounts persisted by an older
+   release keep their stored organization id. Requests for them are now
+   redirected to the token's ChatGPT account id so they reach a real pool
+   instead of being silently mis-billed, but duplicate rows left over from the
+   old one-entry-per-organization behaviour remain until you remove them. For a
+   clean pool, re-run `opencode auth login`, choose the fresh (not `add`) login
+   mode, then add the second workspace.
+
+</details>
+
+<details>
 <summary><b>"All N account(s) failed (server errors or auth issues)"</b></summary>
 
 **Symptoms:**

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -39,6 +39,7 @@ export {
 	extractAccountId,
 	extractAccountEmail,
 	getAccountIdCandidates,
+	relabelCandidateForAccountId,
 	selectBestAccountCandidate,
 	shouldUpdateAccountIdFromToken,
 	resolveRequestAccountId,

--- a/lib/auth/login-runner.ts
+++ b/lib/auth/login-runner.ts
@@ -5,6 +5,11 @@ import {
 	sanitizeEmail,
 	selectBestAccountCandidate,
 } from "../accounts.js";
+// Imported from its defining module rather than through the `../accounts.js`
+// barrel: it is a pure formatter with no reason to be stubbed, and routing it
+// through the barrel would force every suite that mocks accounts.js to
+// re-export it.
+import { relabelCandidateForAccountId } from "./token-utils.js";
 import { logInfo } from "../logger.js";
 import { normalizeScope } from "./scopes.js";
 import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
@@ -218,34 +223,40 @@ export function resolveAccountSelection(tokens: TokenSuccess): AccountSelectionR
 		};
 	}
 
+	// One login yields exactly one persisted account.
+	//
+	// `id_token_add_organizations=true` means the id_token lists every
+	// organization the user belongs to, and this function used to persist one
+	// entry per organization. Every one of those entries shared this login's
+	// single OAuth token, and the Codex backend meters quota by the
+	// `chatgpt-account-id` header while ignoring organization ids - so N entries
+	// all drew from the token's default subscription instead of N pools, and
+	// re-logging in under another workspace overwrote all of them (#226).
+	//
+	// A workspace subscription is its own ChatGPT account with its own
+	// `chatgpt_account_id` claim, so per-entry tokens are what give per-entry
+	// quotas: bind to the token-scoped id and let a second `auth login` under
+	// the other workspace append a separate account carrying its own token.
+	// The chosen workspace's name and organization id ride along as metadata -
+	// `organizationId` is display/dedupe-only and is not sent as a header unless
+	// CODEX_AUTH_SEND_ORGANIZATION_HEADER=1 (see lib/request/fetch-helpers.ts).
+	const routingCandidate =
+		candidates.find((candidate) => candidate.source === "token") ??
+		candidates.find((candidate) => candidate.source === "id_token") ??
+		choice;
 	const primary = createSelectionVariant(tokens, {
-		accountId: choice.accountId,
+		accountId: routingCandidate.accountId,
 		organizationId: choice.organizationId,
-		source: choice.source ?? "token",
-		label: choice.label,
+		source: routingCandidate.source ?? "token",
+		label:
+			routingCandidate === choice
+				? choice.label
+				: relabelCandidateForAccountId(choice.label, routingCandidate.accountId),
 	});
-
-	const variantsForPersistence: TokenSuccessWithAccount[] = [primary];
-	for (const candidate of candidates) {
-		if (
-			candidate.accountId === primary.accountIdOverride &&
-			(candidate.organizationId ?? "") === (primary.organizationIdOverride ?? "")
-		) {
-			continue;
-		}
-		variantsForPersistence.push(
-			createSelectionVariant(tokens, {
-				accountId: candidate.accountId,
-				organizationId: candidate.organizationId,
-				source: candidate.source,
-				label: candidate.label,
-			}),
-		);
-	}
 
 	return {
 		primary,
-		variantsForPersistence,
+		variantsForPersistence: [primary],
 	};
 }
 

--- a/lib/auth/token-utils.ts
+++ b/lib/auth/token-utils.ts
@@ -486,6 +486,26 @@ export function getAccountIdCandidates(
 }
 
 /**
+ * Re-point a candidate label at the account id that actually routes requests.
+ *
+ * Candidate labels embed their own `[id:…]` suffix, and for an org candidate
+ * that suffix is the organization id - which the Codex backend ignores when it
+ * meters quota. Swapping in the routing account's suffix keeps the workspace
+ * name a user recognises while identifying the entry the same way every other
+ * surface does.
+ */
+export function relabelCandidateForAccountId(
+	label: string | undefined,
+	accountId: string,
+): string | undefined {
+	if (!label) return undefined;
+	const base = label.replace(/\s*\[id:[^\]]*\]\s*$/, "").trim();
+	return base
+		? `${base} [id:${formatAccountIdSuffix(accountId)}]`
+		: formatTokenCandidateLabel("Workspace", accountId);
+}
+
+/**
  * Determines if accountId should be updated from a token-derived value.
  * We keep org/manual selections stable across refreshes.
  */
@@ -508,6 +528,18 @@ export function resolveRequestAccountId(
 	tokenAccountId: string | undefined,
 ): string | undefined {
 	if (!storedAccountId) return tokenAccountId;
+	// Entries persisted before #226 carry an organization id as their accountId.
+	// The Codex backend meters quota by the `chatgpt-account-id` header and
+	// ignores organization ids outright, so sending one does not fail loudly -
+	// it silently bills the token's default subscription, which is how two
+	// workspace subscriptions collapsed onto a single pool. Prefer the token's
+	// ChatGPT account id, which does route. `manual` is left alone: a
+	// CODEX_AUTH_ACCOUNT_ID override is a deliberate user choice.
+	//
+	// This only redirects the request header. `shouldUpdateAccountIdFromToken`
+	// still reports `false` for org-sourced entries so the *stored* selection
+	// stays stable across refreshes.
+	if (source === "org") return tokenAccountId ?? storedAccountId;
 	if (!shouldUpdateAccountIdFromToken(source, storedAccountId)) {
 		return storedAccountId;
 	}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5247,7 +5247,7 @@ describe("OpenAIOAuthPlugin persistAccountPool", () => {
 		expect(mockStorage.accounts).toHaveLength(1);
 	});
 
-	it("persists distinct organization candidates from a single login while keeping best candidate primary", async () => {
+	it("persists one token-scoped account per login instead of one per organization", async () => {
 		const accountsModule = await import("../lib/accounts.js");
 		const authModule = await import("../lib/auth/auth.js");
 
@@ -5276,32 +5276,22 @@ describe("OpenAIOAuthPlugin persistAccountPool", () => {
 
 		await autoMethod.authorize({ loginMode: "add", accountCount: "1" });
 
-		expect(mockStorage.accounts).toHaveLength(3);
-		expect(mockStorage.accounts.map((account) => account.accountId)).toEqual([
-			"org-default",
-			"token-personal",
-			"id-secondary",
-		]);
-		expect(mockStorage.accounts.map((account) => account.accountIdSource)).toEqual([
-			"org",
-			"token",
-			"id_token",
-		]);
-		expect(mockStorage.accounts.map((account) => account.accountLabel)).toEqual([
-			"Workspace Alpha [id:fault]",
-			"Token Personal [id:sonal]",
-			"Workspace Beta [id:ndary]",
-		]);
+		// Every candidate shares this login's single OAuth token, so persisting
+		// one entry per organization produced N rows that all drew from the same
+		// quota pool (#226). Only the token-scoped id routes.
+		expect(mockStorage.accounts).toHaveLength(1);
+		expect(mockStorage.accounts[0]?.accountId).toBe("token-personal");
+		expect(mockStorage.accounts[0]?.accountIdSource).toBe("token");
+		// The selected workspace's name survives, re-suffixed with the id that
+		// actually identifies the entry.
+		expect(mockStorage.accounts[0]?.accountLabel).toBe("Workspace Alpha [id:rsonal]");
+		// organizationId is display/dedupe metadata only - it is not sent as a
+		// header unless CODEX_AUTH_SEND_ORGANIZATION_HEADER=1.
+		expect(mockStorage.accounts[0]?.organizationId).toBe("org-default");
 		expect(mockStorage.activeIndex).toBe(0);
-
-		const persistedOrgIds = mockStorage.accounts
-			.map((account) => account.organizationId)
-			.filter((organizationId): organizationId is string => typeof organizationId === "string");
-		// Personal identities are left intact while team org duplicates are collapsed.
-		expect(persistedOrgIds).toEqual(["org-default", "org-personal", "org-secondary"]);
 	});
 
-	it("keeps non-primary candidates persisted even when best candidate differs", async () => {
+	it("binds the login to the token account even when the best candidate is an organization", async () => {
 		const accountsModule = await import("../lib/accounts.js");
 		const authModule = await import("../lib/auth/auth.js");
 
@@ -5330,17 +5320,15 @@ describe("OpenAIOAuthPlugin persistAccountPool", () => {
 		await autoMethod.authorize({ loginMode: "add", accountCount: "1" });
 
 		expect(mockStorage.accounts.map((account) => account.accountId)).toEqual([
-			"org-preferred",
 			"token-first",
 		]);
-		expect(mockStorage.accounts[1]?.accountIdSource).toBe("token");
-		expect(mockStorage.accounts.map((account) => account.organizationId)).toEqual([
-			"org-preferred",
-			"org-token",
-		]);
+		expect(mockStorage.accounts[0]?.accountIdSource).toBe("token");
+		// The preferred workspace still names the entry and supplies its org id.
+		expect(mockStorage.accounts[0]?.organizationId).toBe("org-preferred");
+		expect(mockStorage.accounts[0]?.accountLabel).toBe("Org Preferred [id:-first]");
 	});
 
-	it("preserves duplicate organization candidates when accountId differs", async () => {
+	it("collapses duplicate organization candidates onto the single token account", async () => {
 		const accountsModule = await import("../lib/accounts.js");
 		const authModule = await import("../lib/auth/auth.js");
 
@@ -5379,23 +5367,22 @@ describe("OpenAIOAuthPlugin persistAccountPool", () => {
 
 		await autoMethod.authorize({ loginMode: "add", accountCount: "1" });
 
-		const organizationEntries = mockStorage.accounts.filter(
-			(account) => account.organizationId === "organization-shared",
-		);
-		expect(organizationEntries).toHaveLength(2);
-		const organizationAccountIds = organizationEntries.map((account) => account.accountId).sort();
-		expect(organizationAccountIds).toEqual(["org-variant-a", "org-variant-b"]);
-		expect(mockStorage.accounts).toHaveLength(3);
-		expect(mockStorage.accounts.some((account) => account.accountId === "token-personal")).toBe(true);
+		// Two org rows under one organization are two views of the same
+		// subscription, not two quotas.
+		expect(mockStorage.accounts).toHaveLength(1);
+		expect(mockStorage.accounts[0]?.accountId).toBe("token-personal");
+		expect(mockStorage.accounts[0]?.organizationId).toBe("organization-shared");
+		expect(mockStorage.accounts[0]?.accountLabel).toBe("Org Shared A [id:rsonal]");
 	});
 
-	it("preserves org/no-org shared-refresh entries with different accountId values from a single login", async () => {
+	it("persists a single token-scoped entry when a login yields org and token candidates", async () => {
 		const accountsModule = await import("../lib/accounts.js");
 		const authModule = await import("../lib/auth/auth.js");
 
-		// Simulate a single OAuth login that produces an org candidate + a token candidate.
-		// Both share the same refresh token (same human account).
-		// Since accountId values differ, both should be preserved.
+// Simulate a single OAuth login that produces an org candidate + a token
+		// candidate. They share one refresh token because they are one login, so
+		// they can only ever reach one quota pool - persisting both produced the
+		// duplicate rows with identical quota reported in #226.
 		vi.mocked(authModule.exchangeAuthorizationCode).mockResolvedValueOnce({
 			type: "success",
 			access: "access-holly",
@@ -5431,13 +5418,18 @@ describe("OpenAIOAuthPlugin persistAccountPool", () => {
 
 		await autoMethod.authorize({ loginMode: "add", accountCount: "1" });
 
-		// accountId values differ ("org-QA1bZCn6zb57FT6TXLZWMPO3" vs "e4692e53-2f30-42a0-b8df-3a685d3c2a4a")
-		// so both entries should be preserved despite sharing the same refreshToken.
-		expect(mockStorage.accounts).toHaveLength(2);
-		const accountIds = mockStorage.accounts.map((account) => account.accountId);
-		expect(accountIds).toContain("org-QA1bZCn6zb57FT6TXLZWMPO3");
-		expect(accountIds).toContain("e4692e53-2f30-42a0-b8df-3a685d3c2a4a");
-		expect(mockStorage.accounts.every((account) => account.refreshToken === "refresh-holly-shared")).toBe(true);
+		expect(mockStorage.accounts).toHaveLength(1);
+		expect(mockStorage.accounts[0]?.accountId).toBe(
+			"e4692e53-2f30-42a0-b8df-3a685d3c2a4a",
+		);
+		expect(mockStorage.accounts[0]?.accountIdSource).toBe("token");
+		expect(mockStorage.accounts[0]?.organizationId).toBe(
+			"org-QA1bZCn6zb57FT6TXLZWMPO3",
+		);
+		expect(mockStorage.accounts[0]?.accountLabel).toBe(
+			"Personal (role:owner) [id:3c2a4a]",
+		);
+		expect(mockStorage.accounts[0]?.refreshToken).toBe("refresh-holly-shared");
 	});
 
 	it("updates a unique org-scoped entry when later login lacks organization metadata", async () => {

--- a/test/login-runner.test.ts
+++ b/test/login-runner.test.ts
@@ -13,6 +13,7 @@ import {
 	type TokenSuccessWithAccount,
 } from "../lib/auth/login-runner.js";
 import { loadAccounts, setStoragePathDirect } from "../lib/storage.js";
+import { JWT_CLAIM_PATH } from "../lib/constants.js";
 
 function createTokenResult(
 	accountId: string,
@@ -465,5 +466,200 @@ describe("mergeStoredAccountPair (credential merge semantics)", () => {
 
 		expect(mergeStoredAccountPair(a, b).enabled).toBe(false);
 		expect(mergeStoredAccountPair(b, a).enabled).toBe(false);
+	});
+});
+
+describe("login-runner per-workspace quota binding (#226)", () => {
+	let testDir: string;
+	let storagePath: string;
+
+	beforeEach(async () => {
+		testDir = join(
+			tmpdir(),
+			`login-runner-226-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		storagePath = join(testDir, "oc-codex-multi-auth-accounts.json");
+		await fs.mkdir(testDir, { recursive: true });
+		setStoragePathDirect(storagePath);
+	});
+
+	afterEach(async () => {
+		setStoragePathDirect(null);
+		vi.restoreAllMocks();
+		await fs.rm(testDir, { recursive: true, force: true });
+	});
+
+	const encodeJwt = (payload: Record<string, unknown>): string => {
+		const b64 = (value: unknown) =>
+			Buffer.from(JSON.stringify(value)).toString("base64url");
+		return `${b64({ alg: "none" })}.${b64(payload)}.sig`;
+	};
+
+	/** An access token that names one ChatGPT account, the unit the backend meters. */
+	const accessTokenFor = (chatgptAccountId: string): string =>
+		encodeJwt({ [JWT_CLAIM_PATH]: { chatgpt_account_id: chatgptAccountId } });
+
+	/**
+	 * An id_token from a login with `id_token_add_organizations=true`: it lists
+	 * every organization the Apple ID belongs to, not just the active one.
+	 */
+	const idTokenFor = (
+		organizations: Array<Record<string, unknown>>,
+		extra: Record<string, unknown> = {},
+	): string => encodeJwt({ [JWT_CLAIM_PATH]: { organizations, ...extra } });
+
+	it("persists the token account, not one entry per organization", () => {
+		const selection = resolveAccountSelection({
+			type: "success",
+			access: accessTokenFor("chatgpt-team-account"),
+			refresh: "refresh-team",
+			expires: Date.now() + 60_000,
+			idToken: idTokenFor([
+				{
+					organization_id: "org-acme",
+					name: "Acme",
+					is_default: true,
+					is_personal: false,
+				},
+				{
+					organization_id: "org-personal",
+					name: "Personal",
+					is_personal: true,
+				},
+			]),
+		});
+
+		// Two organizations, one OAuth token, therefore one quota pool.
+		expect(selection.variantsForPersistence).toHaveLength(1);
+		expect(selection.variantsForPersistence[0]).toBe(selection.primary);
+		expect(selection.primary.accountIdOverride).toBe("chatgpt-team-account");
+		expect(selection.primary.accountIdSource).toBe("token");
+		// The active workspace still supplies the name and org id.
+		expect(selection.primary.organizationIdOverride).toBe("org-acme");
+		expect(selection.primary.accountLabel).toBe("Acme [id:ccount]");
+	});
+
+	it("gives each workspace login its own entry, token and quota", async () => {
+		// The #226 repro: one Apple ID, two workspace subscriptions, one
+		// `auth login` per workspace.
+		await persistAccountPool(
+			[
+				resolveAccountSelection({
+					type: "success",
+					access: accessTokenFor("account-team"),
+					refresh: "refresh-team",
+					expires: Date.now() + 60_000,
+					idToken: idTokenFor([
+						{ organization_id: "org-acme", name: "Acme", is_default: true },
+					]),
+				}).primary,
+			],
+			false,
+		);
+		await persistAccountPool(
+			[
+				resolveAccountSelection({
+					type: "success",
+					access: accessTokenFor("account-plus"),
+					refresh: "refresh-plus",
+					expires: Date.now() + 60_000,
+					idToken: idTokenFor([
+						{ organization_id: "org-solo", name: "Solo", is_default: true },
+					]),
+				}).primary,
+			],
+			false,
+		);
+
+		const stored = await loadAccounts();
+		expect(stored?.accounts).toHaveLength(2);
+		// Distinct ChatGPT account ids are what make these distinct quota pools;
+		// distinct refresh tokens are what stop the second login overwriting the
+		// first.
+		expect(stored?.accounts.map((account) => account.accountId)).toEqual([
+			"account-team",
+			"account-plus",
+		]);
+		expect(stored?.accounts.map((account) => account.refreshToken)).toEqual([
+			"refresh-team",
+			"refresh-plus",
+		]);
+	});
+
+	it("re-logging in under the same workspace updates in place", async () => {
+		for (const refresh of ["refresh-first", "refresh-second"]) {
+			await persistAccountPool(
+				[
+					resolveAccountSelection({
+						type: "success",
+						access: accessTokenFor("account-team"),
+						refresh,
+						expires: Date.now() + 60_000,
+						idToken: idTokenFor([
+							{ organization_id: "org-acme", name: "Acme", is_default: true },
+						]),
+					}).primary,
+				],
+				false,
+			);
+		}
+
+		const stored = await loadAccounts();
+		expect(stored?.accounts).toHaveLength(1);
+		expect(stored?.accounts[0]?.refreshToken).toBe("refresh-second");
+	});
+
+	it("falls back to the id_token account when the access token carries no account id", () => {
+		const selection = resolveAccountSelection({
+			type: "success",
+			access: encodeJwt({ [JWT_CLAIM_PATH]: {} }),
+			refresh: "refresh-idtoken",
+			expires: Date.now() + 60_000,
+			idToken: encodeJwt({
+				[JWT_CLAIM_PATH]: {
+					chatgpt_account_id: "id-token-account",
+					organizations: [
+						{ organization_id: "org-acme", name: "Acme", is_default: true },
+					],
+				},
+			}),
+		});
+
+		expect(selection.variantsForPersistence).toHaveLength(1);
+		expect(selection.primary.accountIdOverride).toBe("id-token-account");
+		expect(selection.primary.accountIdSource).toBe("id_token");
+	});
+
+	it("still persists two records that share a refresh token but differ by accountId", async () => {
+		// Guards the persistAccountPool dedup path directly. resolveAccountSelection
+		// no longer emits shared-token variants, but stored pools written before
+		// this change - or by an explicit multi-record persist - must not collapse.
+		await persistAccountPool(
+			[
+				{
+					type: "success",
+					access: accessTokenFor("account-one"),
+					refresh: "refresh-shared",
+					expires: Date.now() + 60_000,
+					accountIdOverride: "account-one",
+					accountIdSource: "token",
+				},
+				{
+					type: "success",
+					access: accessTokenFor("account-two"),
+					refresh: "refresh-shared",
+					expires: Date.now() + 60_000,
+					accountIdOverride: "account-two",
+					accountIdSource: "token",
+				},
+			],
+			false,
+		);
+
+		const stored = await loadAccounts();
+		expect(stored?.accounts.map((account) => account.accountId).sort()).toEqual([
+			"account-one",
+			"account-two",
+		]);
 	});
 });

--- a/test/token-utils.test.ts
+++ b/test/token-utils.test.ts
@@ -942,13 +942,31 @@ describe("Token Utils Module", () => {
 	});
 
 	describe("resolveRequestAccountId", () => {
-		it("preserves org/manual selection when token differs", () => {
+		it("routes org-sourced entries through the token account id", () => {
+			// An organization id is not a chatgpt-account-id. The backend ignores
+			// it and silently bills the token's default subscription, which is how
+			// two workspace subscriptions collapsed onto one quota pool (#226).
 			expect(resolveRequestAccountId("org_business", "org", "token_personal")).toBe(
-				"org_business",
+				"token_personal",
 			);
+		});
+
+		it("keeps a manual override even when the token differs", () => {
 			expect(resolveRequestAccountId("manual_selected", "manual", "token_personal")).toBe(
 				"manual_selected",
 			);
+		});
+
+		it("keeps the stored org id when no token account is available", () => {
+			expect(resolveRequestAccountId("org_business", "org", undefined)).toBe(
+				"org_business",
+			);
+		});
+
+		it("still reports org selections as stable for persistence", () => {
+			// Only the request header is redirected; the stored selection must not
+			// start following token refreshes.
+			expect(shouldUpdateAccountIdFromToken("org", "org_business")).toBe(false);
 		});
 
 		it("follows token for token/id_token sources", () => {


### PR DESCRIPTION
Fixes #226.

## The bug

One ChatGPT login (one email / Apple ID) holding **two workspace subscriptions** — e.g. Team + Plus — collapsed onto a single quota pool. `codex-limits` reported identical plan and percentage for every entry, `codex-switch` to the other account kept draining the same pool, and re-logging in under the other workspace appeared to overwrite every entry.

## Root cause

The OAuth flow requests `id_token_add_organizations=true`, so the id_token lists **every** organization the login belongs to. `resolveAccountSelection` persisted one entry per organization candidate — but all of those entries shared the login's **single OAuth token**.

The Codex backend meters quota by the `chatgpt-account-id` header and **ignores organization ids**. So an entry whose `accountId` was an org id didn't fail loudly; it silently fell back to the token's default subscription. N entries, one pool.

Each workspace subscription is a distinct ChatGPT account with its own `chatgpt_account_id` claim, so **per-entry tokens** are what give per-entry quotas.

This is consistent with what the repo already knows: `lib/request/fetch-helpers.ts` deliberately stopped sending `openai-organization` (see #196) precisely because "workspace routing is carried entirely by `chatgpt-account-id`".

## The fix

**`resolveAccountSelection` (`lib/auth/login-runner.ts`)** — one login now yields exactly one persisted account, bound to the token-scoped ChatGPT account id. Falls back to the id_token account, then to the selected candidate, when the access token carries no `chatgpt_account_id`.

The selected workspace's name and organization id ride along as display/dedupe metadata. `organizationId` is not sent as a header unless `CODEX_AUTH_SEND_ORGANIZATION_HEADER=1`, so this is metadata-only.

A second `opencode auth login` under the other workspace appends a separate account with its own token; re-login under the same workspace still updates in place via the existing `persistAccountPool` dedup.

**`resolveRequestAccountId` (`lib/auth/token-utils.ts`)** — org-sourced entries are redirected to the token's ChatGPT account id, so accounts persisted by an older release reach a real pool instead of being silently mis-billed.

`manual` is untouched (a `CODEX_AUTH_ACCOUNT_ID` override is a deliberate user choice), and `shouldUpdateAccountIdFromToken` still reports `false` for org sources — only the request header is redirected, the *stored* selection stays stable across refreshes.

**`relabelCandidateForAccountId` (new)** — re-points a workspace label at the id that actually routes, so an entry reads `Acme [id:ccount]` rather than carrying an organization-id suffix that names nothing the backend recognises.

## Deliberately out of scope

Duplicate rows already written by the old one-entry-per-organization behaviour are **not** auto-collapsed. Merging stored account records risks discarding single-use refresh tokens, which kills an account permanently. Those rows now route correctly rather than being mis-billed, and `docs/troubleshooting.md` documents the fresh-login path to a clean pool.

## Tests

Four cases in `test/index.test.ts` asserted one-entry-per-organization — they encoded the behaviour this PR fixes, so they are rewritten to the new contract rather than deleted. The `persistAccountPool` dedup they incidentally covered (two records sharing a refresh token but differing by accountId) is now pinned directly in `test/login-runner.test.ts`.

New suite `login-runner per-workspace quota binding (#226)` builds real JWTs and covers:

- persists the token account, not one entry per organization
- gives each workspace login its own entry, token and quota (the #226 repro)
- re-logging in under the same workspace updates in place
- falls back to the id_token account when the access token carries no account id
- still persists two records that share a refresh token but differ by accountId

Four of the five fail against `main`; the other two are deliberate regression guards.

## Verification

- `npm run typecheck` — clean
- `npx eslint lib test --ext .ts` — clean
- `npm test` — **115 files, 2940 passed, 1 skipped, 0 failed**
- Discrimination check: reverted `lib/` to `main` and confirmed the new assertions fail, so they pin the defect rather than passing either way.

Not verified: a live two-subscription login. The issue author confirmed the equivalent patch empirically against `/backend-api/wham/usage` (two entries, one `team` at 98% resetting 18:30 and one `plus` at 95% resetting 20:14, each drawing from its own pool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account and workspace identification for users with multiple ChatGPT subscriptions sharing one login.
  * Prevented duplicate account entries and ensured usage quotas are associated with the correct workspace.
  * Preserved credentials and workspace details when signing in again or switching between workspaces.

* **Documentation**
  * Added troubleshooting guidance covering login behavior, workspace migration, duplicate entries, cleanup, and independent quota requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr binds each new login to its token-scoped chatgpt account and redirects legacy organization-sourced requests through the token account id.
- persists one account per oauth login while retaining workspace metadata
- adds request-time compatibility routing for legacy organization records
- adds quota-binding, relabeling, deduplication, and troubleshooting coverage
- token safety is preserved by retaining distinct refresh-token records; no new windows filesystem or production concurrency path is introduced

<h3>Confidence Score: 4/5</h3>

the pr appears safe to merge, with one non-blocking gap in vitest coverage for the organization-only routing fallback.

the primary token-scoped login and legacy request-routing paths are covered, while the new final fallback can still regress without a focused test.

**Files Needing Attention:** lib/auth/login-runner.ts, test/login-runner.test.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/auth/login-runner.ts | binds each login to one routable token account, but the final organization-only fallback lacks focused vitest coverage |
| lib/auth/token-utils.ts | adds label rewriting and redirects legacy org-sourced request ids without mutating stored selections |
| test/login-runner.test.ts | covers separate workspace tokens, relogin deduplication, and id-token fallback, but not the both-token-claims-missing branch |
| test/token-utils.test.ts | directly covers org request redirection, manual overrides, and persistence stability |
| docs/troubleshooting.md | documents the legacy duplicate-row limitation and safe fresh-login recovery path |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[oauth login] --> B[extract account candidates]
  B --> C{token account id present?}
  C -->|yes| D[persist one token-scoped account]
  C -->|no| E{id-token account id present?}
  E -->|yes| D
  E -->|no| F[selected organization fallback]
  D --> G[persistAccountPool transaction]
  G --> H[request selection]
  H --> I[resolveRequestAccountId]
  I --> J[chatgpt-account-id header]
  K[legacy org-sourced record] --> I
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fissue-226-per-workspace-quota%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fissue-226-per-workspace-quota%22.%0A%0A%23%23%23%20Issue%201%0Alib%2Fauth%2Flogin-runner.ts%3A243-246%0A**cover%20the%20organization-only%20fallback**%0A%0Aadd%20vitest%20coverage%20for%20oauth%20responses%20where%20both%20tokens%20omit%20%60chatgpt_account_id%60%20but%20organization%20candidates%20remain.%20this%20fallback%20persists%20an%20organization%20id%20that%20is%20later%20eligible%20for%20the%20request%20header%2C%20so%20an%20untested%20regression%20here%20can%20silently%20defeat%20workspace%20quota%20binding.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ndycode%2Foc-codex-multi-auth&pr=227&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/auth/login-runner.ts:243-246
**cover the organization-only fallback**

add vitest coverage for oauth responses where both tokens omit `chatgpt_account_id` but organization candidates remain. this fallback persists an organization id that is later eligible for the request header, so an untested regression here can silently defeat workspace quota binding.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(auth): bind each login to its own wo..."](https://github.com/ndycode/oc-codex-multi-auth/commit/7f96f94be8ead5d3a7ca70f5de516d2a26cf7bd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52248646)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - speak in lowercase, concise sentences. act like th... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [OAuth login and token refresh](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/auth-oauth.md)
- Knowledge Base — [Multi-Account Rotation and Health](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/accounts-rotation.md)
</details>

<!-- /greptile_comment -->