### PR TITLE
fix(config): bound contention stall and align the lock error surface

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -140,6 +140,32 @@ Update your `~/.config/opencode/opencode.json`:
 
 ---
 
+## Concurrent Sessions & Storage
+
+<details>
+<summary><b><code>codex-pool</code> reports that plugin configuration is locked</b></summary>
+
+**Symptoms:**
+- A pool mutation reports `config_locked` with `retryable: true` in JSON output.
+- Text output says the plugin configuration is locked by another process and no change was made.
+
+**Cause:** Another OpenCode process is updating `~/.opencode/openai-codex-auth-config.json`. Pool dry-runs and true no-op mutations do not acquire this lock; changes wait for a bounded retry window before returning this signal.
+
+**Solution:** No partial change was applied. Retry the same `codex-pool` action shortly. If contention persists, finish or stop other processes that are actively changing plugin configuration, then retry.
+
+</details>
+
+<details>
+<summary><b><code>Multi-worktree collision detected on account storage</code> warning</b></summary>
+
+This advisory warning means another live process or host is using the same account-storage file. It includes the foreign and local PID, host, and working directory so you can identify the sessions. Reads and writes continue because the worktree lock is intentionally advisory; repeated warnings are throttled to once per minute.
+
+If account rotation or rate-limit state appears stale, close the duplicate session or ensure each worktree resolves to the intended project storage, then restart OpenCode and inspect the account list. Do not delete a lock belonging to a live process.
+
+</details>
+
+---
+
 ## Authentication Issues
 
 <details open>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -149,7 +149,7 @@ Update your `~/.config/opencode/opencode.json`:
 - A pool mutation reports `config_locked` with `retryable: true` in JSON output.
 - Text output says the plugin configuration is locked by another process and no change was made.
 
-**Cause:** Another OpenCode process is updating `~/.opencode/openai-codex-auth-config.json`. Pool dry-runs and true no-op mutations do not acquire this lock; changes wait for a bounded retry window before returning this signal.
+**Cause:** Another OpenCode process is updating `~/.opencode/openai-codex-auth-config.json`. Pool dry-runs do not acquire this lock. Every non-dry mutation, including a possible no-op, waits for the bounded retry window and is revalidated under the lock so its result cannot rely on a stale preview.
 
 **Solution:** No partial change was applied. Retry the same `codex-pool` action shortly. If contention persists, finish or stop other processes that are actively changing plugin configuration, then retry.
 
@@ -158,7 +158,7 @@ Update your `~/.config/opencode/opencode.json`:
 <details>
 <summary><b><code>Multi-worktree collision detected on account storage</code> warning</b></summary>
 
-This advisory warning means another live process or host is using the same account-storage file. It includes the foreign and local PID, host, and working directory so you can identify the sessions. Reads and writes continue because the worktree lock is intentionally advisory; repeated warnings are throttled to once per minute.
+This advisory warning means another live process or host is using the same account-storage file. It includes the foreign and local PID, host, and working directory so you can identify the sessions. Reads and writes continue because the worktree lock is intentionally advisory; repeated warnings are throttled to once per minute for each storage path and foreign lock generation.
 
 If account rotation or rate-limit state appears stale, close the duplicate session or ensure each worktree resolves to the intended project storage, then restart OpenCode and inspect the account list. Do not delete a lock belonging to a live process.
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -16,8 +16,6 @@ import {
 	renameWithWindowsRetry,
 } from "./storage/atomic-write.js";
 import { ConfigLockContentionError } from "./errors.js";
-
-export { ConfigLockContentionError } from "./errors.js";
 import {
 	PluginConfigSchema,
 	getValidationErrors,
@@ -170,6 +168,71 @@ export function loadPluginConfig(): PluginConfig {
 	}
 }
 
+type LockRetryBudget = {
+	retries: number;
+	factor: number;
+	minTimeout: number;
+	maxTimeout: number;
+	randomize: boolean;
+};
+
+/**
+ * Full budget: roughly three seconds of retries, enough to ride out another
+ * process finishing a mutation of its own.
+ */
+const LOCK_RETRY_BUDGET_FULL: LockRetryBudget = {
+	retries: 20,
+	factor: 1.2,
+	minTimeout: 25,
+	maxTimeout: 200,
+	randomize: true,
+};
+
+/**
+ * Short budget used once contention has just been observed: long enough to win
+ * a lock its holder is releasing right now, far short of the full budget.
+ */
+const LOCK_RETRY_BUDGET_PROBE: LockRetryBudget = {
+	retries: 3,
+	factor: 1.2,
+	minTimeout: 25,
+	maxTimeout: 50,
+	randomize: true,
+};
+
+/** How long one contention observation keeps later mutations on the probe budget. */
+const LOCK_CONTENTION_FAST_FAIL_WINDOW_MS = 1_000;
+
+/**
+ * When another process was last seen holding the config lock past our budget.
+ *
+ * `modelAccountPoolMutationQueue` serializes every in-process mutation, so
+ * without this each queued caller independently waited out the full budget
+ * against the same foreign holder: ten parallel `codex-pool` calls blocked for
+ * ten times the budget and then all failed anyway, which is the "completely
+ * stalls the sub tasks" half of #224. Once one call has established that the
+ * lock is externally held, the rest probe briefly and degrade immediately, so
+ * the stall is bounded rather than multiplied by the queue depth.
+ */
+let lastLockContentionAt: number | null = null;
+
+function nextLockRetryBudget(): LockRetryBudget {
+	if (lastLockContentionAt === null) return LOCK_RETRY_BUDGET_FULL;
+	if (
+		Date.now() - lastLockContentionAt >=
+		LOCK_CONTENTION_FAST_FAIL_WINDOW_MS
+	) {
+		lastLockContentionAt = null;
+		return LOCK_RETRY_BUDGET_FULL;
+	}
+	return LOCK_RETRY_BUDGET_PROBE;
+}
+
+/** Test hook: forget any observed contention so budgets start from full. */
+export function __resetLockContentionStateForTests(): void {
+	lastLockContentionAt = null;
+}
+
 /**
  * Update one model pool while preserving every unrelated raw config key.
  * Account indexes are deliberately resolved by the caller; only stable IDs
@@ -211,16 +274,12 @@ export function updateModelAccountPool(
 						`Plugin configuration lock at ${CONFIG_PATH} was compromised mid-mutation: ${error.message}`,
 					);
 				},
-				retries: {
-					retries: 22,
-					factor: 1.2,
-					minTimeout: 25,
-					maxTimeout: 225,
-					randomize: true,
-				},
+				retries: nextLockRetryBudget(),
 			});
+			lastLockContentionAt = null;
 		} catch (error) {
 			if (isLockContentionError(error)) {
+				lastLockContentionAt = Date.now();
 				throw new ConfigLockContentionError(CONFIG_PATH, error);
 			}
 			throw error;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -179,14 +179,13 @@ export function updateModelAccountPool(
 	options: { dryRun?: boolean; poolMode?: ModelAccountPoolMode } = {},
 ): Promise<ModelAccountPoolMutationResult> {
 	const pending = modelAccountPoolMutationQueue.then(async () => {
-		const preview = await performModelAccountPoolMutation(
-			model,
-			mutation,
-			accountIds,
-			{ ...options, dryRun: true },
-		);
-		if (options.dryRun === true || !preview.changed) {
-			return { ...preview, dryRun: options.dryRun === true };
+		if (options.dryRun === true) {
+			return performModelAccountPoolMutation(
+				model,
+				mutation,
+				accountIds,
+				options,
+			);
 		}
 
 		await fs.mkdir(dirname(CONFIG_PATH), { recursive: true, mode: 0o700 });
@@ -205,7 +204,7 @@ export function updateModelAccountPool(
 				},
 			});
 		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code === "ELOCKED") {
+			if (hasErrorCode(error, "ELOCKED")) {
 				throw new ConfigLockContentionError(CONFIG_PATH, error);
 			}
 			throw error;
@@ -226,6 +225,15 @@ export function updateModelAccountPool(
 		() => undefined,
 	);
 	return pending;
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		"code" in error &&
+		error.code === code
+	);
 }
 
 async function performModelAccountPoolMutation(

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -12,6 +12,9 @@ import {
 import { logWarn } from "./logger.js";
 import { stripEffortSuffix } from "./request/helpers/effort-suffix.js";
 import { renameWithWindowsRetry } from "./storage/atomic-write.js";
+import { ConfigLockContentionError } from "./errors.js";
+
+export { ConfigLockContentionError } from "./errors.js";
 import {
 	PluginConfigSchema,
 	getValidationErrors,
@@ -176,19 +179,37 @@ export function updateModelAccountPool(
 	options: { dryRun?: boolean; poolMode?: ModelAccountPoolMode } = {},
 ): Promise<ModelAccountPoolMutationResult> {
 	const pending = modelAccountPoolMutationQueue.then(async () => {
+		const preview = await performModelAccountPoolMutation(
+			model,
+			mutation,
+			accountIds,
+			{ ...options, dryRun: true },
+		);
+		if (options.dryRun === true || !preview.changed) {
+			return { ...preview, dryRun: options.dryRun === true };
+		}
+
 		await fs.mkdir(dirname(CONFIG_PATH), { recursive: true, mode: 0o700 });
-		const release = await lock(CONFIG_PATH, {
-			realpath: false,
-			stale: 10_000,
-			update: 2_000,
-			retries: {
-				retries: 20,
-				factor: 1.2,
-				minTimeout: 25,
-				maxTimeout: 200,
-				randomize: true,
-			},
-		});
+		let release: () => Promise<void>;
+		try {
+			release = await lock(CONFIG_PATH, {
+				realpath: false,
+				stale: 10_000,
+				update: 2_000,
+				retries: {
+					retries: 22,
+					factor: 1.2,
+					minTimeout: 25,
+					maxTimeout: 225,
+					randomize: true,
+				},
+			});
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "ELOCKED") {
+				throw new ConfigLockContentionError(CONFIG_PATH, error);
+			}
+			throw error;
+		}
 		try {
 			return await performModelAccountPoolMutation(
 				model,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -11,7 +11,10 @@ import {
 } from "./request/retry-budget.js";
 import { logWarn } from "./logger.js";
 import { stripEffortSuffix } from "./request/helpers/effort-suffix.js";
-import { renameWithWindowsRetry } from "./storage/atomic-write.js";
+import {
+	isWindowsLockError,
+	renameWithWindowsRetry,
+} from "./storage/atomic-write.js";
 import { ConfigLockContentionError } from "./errors.js";
 
 export { ConfigLockContentionError } from "./errors.js";
@@ -195,6 +198,19 @@ export function updateModelAccountPool(
 				realpath: false,
 				stale: 10_000,
 				update: 2_000,
+				// proper-lockfile's default `onCompromised` rethrows from inside an
+				// fs callback. Nothing in this process installs an
+				// `uncaughtException` handler, so a lock that goes stale mid-mutation
+				// (event loop blocked past `stale`, or another process reclaiming the
+				// entry) would take the whole plugin down instead of failing this one
+				// call. The mutation is already in flight and cannot be rolled back,
+				// so the only useful response is to record it; the release below
+				// tolerates the ERELEASED that follows.
+				onCompromised: (error: Error) => {
+					logWarn(
+						`Plugin configuration lock at ${CONFIG_PATH} was compromised mid-mutation: ${error.message}`,
+					);
+				},
 				retries: {
 					retries: 22,
 					factor: 1.2,
@@ -204,7 +220,7 @@ export function updateModelAccountPool(
 				},
 			});
 		} catch (error) {
-			if (hasErrorCode(error, "ELOCKED")) {
+			if (isLockContentionError(error)) {
 				throw new ConfigLockContentionError(CONFIG_PATH, error);
 			}
 			throw error;
@@ -217,7 +233,12 @@ export function updateModelAccountPool(
 				options,
 			);
 		} finally {
-			await release();
+			// A release failure must never replace the mutation's outcome. By this
+			// point the config has already been written, so surfacing ERELEASED (or
+			// a Windows EPERM/EBUSY on the lock directory, which `removeLock`
+			// propagates straight from `rmdir`) would report a fatal lock error for
+			// a change that actually landed - the exact symptom this fix removes.
+			await releaseLockQuietly(release);
 		}
 	});
 	modelAccountPoolMutationQueue = pending.then(
@@ -234,6 +255,40 @@ function hasErrorCode(error: unknown, code: string): boolean {
 		"code" in error &&
 		error.code === code
 	);
+}
+
+/**
+ * True when a lock acquisition failure means "another process holds it", as
+ * opposed to a genuine environment fault the caller must see.
+ *
+ * proper-lockfile forwards raw fs errors from the lock directory's
+ * `mkdir`/`stat`/`rmdir` straight into its retry loop, so the error that
+ * finally escapes (`operation.mainError()`) is not always ELOCKED. On Windows a
+ * lock directory held open by another process - or by an antivirus scanner or
+ * the search indexer - surfaces as EPERM/EBUSY rather than EEXIST, the same
+ * class `renameWithWindowsRetry` already tolerates one layer down. Those codes
+ * count as contention only on win32; on POSIX an EPERM really is a permission
+ * problem and has to stay fatal.
+ */
+function isLockContentionError(error: unknown): boolean {
+	if (hasErrorCode(error, "ELOCKED")) return true;
+	return process.platform === "win32" && isWindowsLockError(error);
+}
+
+/** Release a config lock, downgrading any failure to a warning. */
+async function releaseLockQuietly(release: () => Promise<void>): Promise<void> {
+	try {
+		await release();
+	} catch (error) {
+		// Losing the lock directory is recoverable on its own: `stale` reclaims a
+		// leftover entry within 10s, and the mutation it guarded is already
+		// durable on disk.
+		logWarn(
+			`Failed to release plugin configuration lock at ${CONFIG_PATH}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
 }
 
 async function performModelAccountPoolMutation(

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -320,9 +320,20 @@ export class ConfigError extends CodexError {
 	}
 }
 
-export class ConfigLockContentionError extends ConfigError {
+/**
+ * Another process currently holds the plugin configuration lock.
+ *
+ * Deliberately NOT a {@link ConfigError}: that class means "the user's
+ * configuration is wrong" (missing TTY, malformed CLI input, bad format flags),
+ * and any handler catching it to print "fix your configuration" and stop
+ * retrying would give exactly the wrong advice for a condition that resolves on
+ * its own. It sits with the transient family instead and carries `retryable`
+ * the same way {@link CodexNetworkError} does.
+ */
+export class ConfigLockContentionError extends CodexError {
 	override readonly name = "ConfigLockContentionError";
 	readonly path: string;
+	readonly retryable = true;
 
 	constructor(path: string, cause?: unknown) {
 		super(`Plugin configuration at ${path} is locked by another process.`, {

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -38,6 +38,7 @@ export const ErrorCode = {
 	PROMPT_ERROR: "CODEX_PROMPT_ERROR",
 	REQUEST_ERROR: "CODEX_REQUEST_ERROR",
 	CONFIG_ERROR: "CODEX_CONFIG_ERROR",
+	CONFIG_LOCK_CONTENTION: "CODEX_CONFIG_LOCK_CONTENTION",
 } as const;
 
 export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];
@@ -309,12 +310,26 @@ export class RequestError extends CodexError {
  * input, bad format flags, missing required options).
  */
 export class ConfigError extends CodexError {
-	override readonly name = "ConfigError";
+	override readonly name: string = "ConfigError";
 
 	constructor(message: string, options?: CodexErrorOptions) {
 		super(message, {
 			...options,
 			code: options?.code ?? ErrorCode.CONFIG_ERROR,
 		});
+	}
+}
+
+export class ConfigLockContentionError extends ConfigError {
+	override readonly name = "ConfigLockContentionError";
+	readonly path: string;
+
+	constructor(path: string, cause?: unknown) {
+		super(`Plugin configuration at ${path} is locked by another process.`, {
+			code: ErrorCode.CONFIG_LOCK_CONTENTION,
+			cause,
+			context: { path },
+		});
+		this.path = path;
 	}
 }

--- a/lib/storage/atomic-write.ts
+++ b/lib/storage/atomic-write.ts
@@ -15,7 +15,7 @@ export const WINDOWS_RENAME_RETRY_ATTEMPTS = 5;
 export const WINDOWS_RENAME_RETRY_BASE_DELAY_MS = 10;
 export const PRE_IMPORT_BACKUP_WRITE_TIMEOUT_MS = 3_000;
 
-function isWindowsLockError(error: unknown): error is NodeJS.ErrnoException {
+export function isWindowsLockError(error: unknown): error is NodeJS.ErrnoException {
   const code = (error as NodeJS.ErrnoException)?.code;
   return code === "EPERM" || code === "EBUSY";
 }

--- a/lib/storage/load-save.ts
+++ b/lib/storage/load-save.ts
@@ -49,10 +49,44 @@ import os from "node:os";
 
 const log = createLogger("storage");
 const COLLISION_WARNING_THROTTLE_MS = 60_000;
-let lastCollisionWarningAt: number | undefined;
+const COLLISION_WARNING_THROTTLE_MAX_ENTRIES = 128;
+const collisionWarningTimes = new Map<string, number>();
 
 export function __resetCollisionWarningThrottleForTests(): void {
-  lastCollisionWarningAt = undefined;
+  collisionWarningTimes.clear();
+}
+
+function shouldWarnForCollision(
+  storagePath: string,
+  foreign: { hostname: string; pid: number; startedAt: string },
+): boolean {
+  const now = Date.now();
+  for (const [key, warnedAt] of collisionWarningTimes) {
+    if (
+      now < warnedAt ||
+      now - warnedAt >= COLLISION_WARNING_THROTTLE_MS
+    ) {
+      collisionWarningTimes.delete(key);
+    }
+  }
+
+  const key = JSON.stringify([
+    storagePath,
+    foreign.hostname,
+    foreign.pid,
+    foreign.startedAt,
+  ]);
+  if (collisionWarningTimes.has(key)) return false;
+
+  collisionWarningTimes.set(key, now);
+  while (
+    collisionWarningTimes.size > COLLISION_WARNING_THROTTLE_MAX_ENTRIES
+  ) {
+    const oldestKey = collisionWarningTimes.keys().next().value;
+    if (oldestKey === undefined) break;
+    collisionWarningTimes.delete(oldestKey);
+  }
+  return true;
 }
 
 /**
@@ -85,12 +119,7 @@ async function checkWorktreeLockForCurrentStorage(
   try {
     const result = await acquireOrDetectLock(path);
     if (!result.acquired && result.foreign) {
-      const now = Date.now();
-      if (
-        lastCollisionWarningAt === undefined ||
-        now - lastCollisionWarningAt >= COLLISION_WARNING_THROTTLE_MS
-      ) {
-        lastCollisionWarningAt = now;
+      if (shouldWarnForCollision(path, result.foreign)) {
         log.warn("Multi-worktree collision detected on account storage", {
           operation,
           storagePath: path,

--- a/lib/storage/load-save.ts
+++ b/lib/storage/load-save.ts
@@ -56,27 +56,44 @@ export function __resetCollisionWarningThrottleForTests(): void {
   collisionWarningTimes.clear();
 }
 
-function shouldWarnForCollision(
+/**
+ * Identity a collision warning is throttled against.
+ *
+ * Deliberately storage path + host only. Including the foreign `pid` and
+ * `startedAt` meant a foreign holder that restarts - or several short-lived
+ * sessions rotating - produced a brand new key on every probe, so the throttle
+ * never fired and the log spam it exists to stop continued unabated. Those dead
+ * identities also evicted live ones from the bounded map, which could stop a
+ * genuinely recurring collision from ever being deduped.
+ */
+function collisionWarningKey(
   storagePath: string,
-  foreign: { hostname: string; pid: number; startedAt: string },
-): boolean {
-  const now = Date.now();
-  for (const [key, warnedAt] of collisionWarningTimes) {
-    if (
-      now < warnedAt ||
-      now - warnedAt >= COLLISION_WARNING_THROTTLE_MS
-    ) {
-      collisionWarningTimes.delete(key);
+  foreign: { hostname: string },
+): string {
+  return JSON.stringify([storagePath, foreign.hostname]);
+}
+
+/** Pure query: has this identity already warned inside the current window? */
+function hasWarnedForCollision(key: string, now: number): boolean {
+  const warnedAt = collisionWarningTimes.get(key);
+  if (warnedAt === undefined) return false;
+  if (now < warnedAt) return false;
+  return now - warnedAt < COLLISION_WARNING_THROTTLE_MS;
+}
+
+/**
+ * Record a warning the caller has already emitted.
+ *
+ * Split from the check, and called after the emit, so a `log.warn` that throws
+ * cannot leave the throttle believing it warned - which would silently suppress
+ * the next 60s of collisions.
+ */
+function recordCollisionWarning(key: string, now: number): void {
+  for (const [existingKey, warnedAt] of collisionWarningTimes) {
+    if (now < warnedAt || now - warnedAt >= COLLISION_WARNING_THROTTLE_MS) {
+      collisionWarningTimes.delete(existingKey);
     }
   }
-
-  const key = JSON.stringify([
-    storagePath,
-    foreign.hostname,
-    foreign.pid,
-    foreign.startedAt,
-  ]);
-  if (collisionWarningTimes.has(key)) return false;
 
   collisionWarningTimes.set(key, now);
   while (
@@ -86,7 +103,6 @@ function shouldWarnForCollision(
     if (oldestKey === undefined) break;
     collisionWarningTimes.delete(oldestKey);
   }
-  return true;
 }
 
 /**
@@ -119,7 +135,9 @@ async function checkWorktreeLockForCurrentStorage(
   try {
     const result = await acquireOrDetectLock(path);
     if (!result.acquired && result.foreign) {
-      if (shouldWarnForCollision(path, result.foreign)) {
+      const now = Date.now();
+      const warningKey = collisionWarningKey(path, result.foreign);
+      if (!hasWarnedForCollision(warningKey, now)) {
         log.warn("Multi-worktree collision detected on account storage", {
           operation,
           storagePath: path,
@@ -131,6 +149,7 @@ async function checkWorktreeLockForCurrentStorage(
           ourHost: os.hostname(),
           ourCwd: process.cwd(),
         });
+        recordCollisionWarning(warningKey, now);
       }
     }
   } catch (error) {

--- a/lib/storage/load-save.ts
+++ b/lib/storage/load-save.ts
@@ -48,6 +48,12 @@ import {
 import os from "node:os";
 
 const log = createLogger("storage");
+const COLLISION_WARNING_THROTTLE_MS = 60_000;
+let lastCollisionWarningAt: number | undefined;
+
+export function __resetCollisionWarningThrottleForTests(): void {
+  lastCollisionWarningAt = undefined;
+}
 
 /**
  * Probes the worktree lock for the currently active storage path and surfaces
@@ -79,17 +85,24 @@ async function checkWorktreeLockForCurrentStorage(
   try {
     const result = await acquireOrDetectLock(path);
     if (!result.acquired && result.foreign) {
-      log.warn("Multi-worktree collision detected on account storage", {
-        operation,
-        storagePath: path,
-        foreignPid: result.foreign.pid,
-        foreignHost: result.foreign.hostname,
-        foreignCwd: result.foreign.cwd,
-        foreignLastActive: result.foreign.lastActive,
-        ourPid: process.pid,
-        ourHost: os.hostname(),
-        ourCwd: process.cwd(),
-      });
+      const now = Date.now();
+      if (
+        lastCollisionWarningAt === undefined ||
+        now - lastCollisionWarningAt >= COLLISION_WARNING_THROTTLE_MS
+      ) {
+        lastCollisionWarningAt = now;
+        log.warn("Multi-worktree collision detected on account storage", {
+          operation,
+          storagePath: path,
+          foreignPid: result.foreign.pid,
+          foreignHost: result.foreign.hostname,
+          foreignCwd: result.foreign.cwd,
+          foreignLastActive: result.foreign.lastActive,
+          ourPid: process.pid,
+          ourHost: os.hostname(),
+          ourCwd: process.cwd(),
+        });
+      }
     }
   } catch (error) {
     log.debug("Worktree lock probe failed", {

--- a/lib/tools/codex-pool.ts
+++ b/lib/tools/codex-pool.ts
@@ -2,7 +2,6 @@
 
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
 import {
-	ConfigLockContentionError,
 	getModelAccountPoolMode,
 	loadPluginConfig,
 	type ModelAccountPoolMode,
@@ -10,6 +9,7 @@ import {
 	updateModelAccountPool,
 	type ModelAccountPoolMutation,
 } from "../config.js";
+import { ConfigLockContentionError, ErrorCode } from "../errors.js";
 import { logWarn } from "../logger.js";
 import { normalizeToolOutputFormat, renderJsonOutput } from "../runtime.js";
 import { loadAccounts, type AccountStorageV3 } from "../storage.js";
@@ -266,12 +266,43 @@ export function createCodexPoolTool(ctx: ToolContext): ToolDefinition {
 					model,
 				});
 				if (format === "json") {
+					// Mirror the success payload's shape. Dropping `pool`,
+					// `previousPoolMode` and friends makes every consumer that reads
+					// `pool.accounts` throw a TypeError - a harder failure than the raw
+					// lock error this degrade path replaced. Nothing was mutated, so the
+					// pool currently on disk is the accurate answer.
+					const config = loadPluginConfig();
+					const currentAccountIds = Array.from(
+						new Set(
+							Object.entries(config.modelAccountPools ?? {})
+								.filter(
+									([configuredModel]) =>
+										configuredModel.trim().toLowerCase() === model,
+								)
+								.flatMap(([, ids]) => ids ?? []),
+						),
+					);
+					const currentPoolMode = getModelAccountPoolMode(config, model);
 					return renderJsonOutput({
 						action,
 						model,
 						changed: false,
 						applied: false,
-						error: "config_locked",
+						dryRun: args.dryRun === true,
+						restartRequired: false,
+						previousConfiguredCount: currentAccountIds.length,
+						previousPoolMode: currentPoolMode,
+						pool: buildPoolSnapshot(
+							model,
+							currentAccountIds,
+							storage,
+							ctx,
+							includeSensitive,
+							currentPoolMode,
+						),
+						// Same identifier the class and the logs use, so a caller that
+						// greps for what it saw in tool JSON actually finds something.
+						error: ErrorCode.CONFIG_LOCK_CONTENTION,
 						retryable: true,
 						message,
 					});

--- a/lib/tools/codex-pool.ts
+++ b/lib/tools/codex-pool.ts
@@ -2,12 +2,15 @@
 
 import { tool, type ToolDefinition } from "@opencode-ai/plugin/tool";
 import {
+	ConfigLockContentionError,
 	getModelAccountPoolMode,
 	loadPluginConfig,
 	type ModelAccountPoolMode,
+	type ModelAccountPoolMutationResult,
 	updateModelAccountPool,
 	type ModelAccountPoolMutation,
 } from "../config.js";
+import { logWarn } from "../logger.js";
 import { normalizeToolOutputFormat, renderJsonOutput } from "../runtime.js";
 import { loadAccounts, type AccountStorageV3 } from "../storage.js";
 import type { ToolContext } from "./index.js";
@@ -247,10 +250,34 @@ export function createCodexPoolTool(ctx: ToolContext): ToolDefinition {
 				action === "clear" || action === "set-mode"
 					? []
 					: resolveAccountIds(storage, args.accounts);
-			const result = await updateModelAccountPool(model, action, accountIds, {
-				dryRun: args.dryRun,
-				poolMode,
-			});
+			let result: ModelAccountPoolMutationResult;
+			try {
+				result = await updateModelAccountPool(model, action, accountIds, {
+					dryRun: args.dryRun,
+					poolMode,
+				});
+			} catch (error) {
+				if (!(error instanceof ConfigLockContentionError)) throw error;
+
+				const message =
+					"The plugin configuration is locked by another process. No change was made — retry shortly.";
+				logWarn("codex-pool could not acquire the plugin configuration lock", {
+					action,
+					model,
+				});
+				if (format === "json") {
+					return renderJsonOutput({
+						action,
+						model,
+						changed: false,
+						applied: false,
+						error: "config_locked",
+						retryable: true,
+						message,
+					});
+				}
+				return `Could not update the account pool for ${model}: ${message}`;
+			}
 			const pool = buildPoolSnapshot(
 				result.model,
 				result.accountIds,

--- a/test/config-lock-contention.test.ts
+++ b/test/config-lock-contention.test.ts
@@ -1,0 +1,53 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { promises as fs } from "node:fs";
+
+const { lockMock } = vi.hoisted(() => ({ lockMock: vi.fn() }));
+const testHome = vi.hoisted(
+	() => `/tmp/oc-codex-config-lock-contention-${process.pid}`,
+);
+
+vi.mock("proper-lockfile", () => ({ lock: lockMock }));
+vi.mock("node:os", async () => {
+	const actual = await vi.importActual<typeof import("node:os")>("node:os");
+	return { ...actual, homedir: () => testHome };
+});
+
+import {
+	ConfigLockContentionError,
+	updateModelAccountPool,
+} from "../lib/config.js";
+
+describe("model account pool config lock contention", () => {
+	beforeEach(async () => {
+		lockMock.mockReset();
+		await fs.rm(testHome, { recursive: true, force: true });
+	});
+
+	afterAll(async () => {
+		await fs.rm(testHome, { recursive: true, force: true });
+	});
+
+	it("classifies only exhausted proper-lockfile acquisition", async () => {
+		const cause = Object.assign(new Error("already held"), { code: "ELOCKED" });
+		lockMock.mockRejectedValue(cause);
+
+		const pending = updateModelAccountPool("model", "set", ["one"]);
+
+		await expect(pending).rejects.toMatchObject({
+			name: "ConfigLockContentionError",
+			code: "CODEX_CONFIG_LOCK_CONTENTION",
+			path: `${testHome}/.opencode/openai-codex-auth-config.json`,
+			cause,
+		});
+		await expect(pending).rejects.toBeInstanceOf(ConfigLockContentionError);
+	});
+
+	it("preserves non-contention lock acquisition failures", async () => {
+		const cause = Object.assign(new Error("permission denied"), { code: "EACCES" });
+		lockMock.mockRejectedValue(cause);
+
+		await expect(
+			updateModelAccountPool("model", "set", ["one"]),
+		).rejects.toBe(cause);
+	});
+});

--- a/test/config-lock-contention.test.ts
+++ b/test/config-lock-contention.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { promises as fs } from "node:fs";
+import { dirname, join } from "node:path";
 
 const { lockMock } = vi.hoisted(() => ({ lockMock: vi.fn() }));
 const testHome = vi.hoisted(
@@ -18,6 +19,12 @@ import {
 } from "../lib/config.js";
 
 describe("model account pool config lock contention", () => {
+	const configPath = join(
+		testHome,
+		".opencode",
+		"openai-codex-auth-config.json",
+	);
+
 	beforeEach(async () => {
 		lockMock.mockReset();
 		await fs.rm(testHome, { recursive: true, force: true });
@@ -49,5 +56,40 @@ describe("model account pool config lock contention", () => {
 		await expect(
 			updateModelAccountPool("model", "set", ["one"]),
 		).rejects.toBe(cause);
+	});
+
+	it("revalidates a non-dry no-op after acquiring the lock", async () => {
+		await fs.mkdir(dirname(configPath), { recursive: true });
+		await fs.writeFile(
+			configPath,
+			JSON.stringify({ modelAccountPools: { model: ["one"] } }),
+			"utf8",
+		);
+		lockMock.mockImplementationOnce(async () => {
+			await fs.writeFile(
+				configPath,
+				JSON.stringify({ modelAccountPools: { model: [] } }),
+				"utf8",
+			);
+			return async () => {};
+		});
+
+		const result = await updateModelAccountPool("model", "set", ["one"]);
+		const persisted = JSON.parse(await fs.readFile(configPath, "utf8")) as {
+			modelAccountPools: Record<string, string[]>;
+		};
+
+		expect(lockMock).toHaveBeenCalledTimes(1);
+		expect(result.changed).toBe(true);
+		expect(result.previousAccountIds).toEqual([]);
+		expect(persisted.modelAccountPools.model).toEqual(["one"]);
+	});
+
+	it("preserves malformed lock acquisition rejections", async () => {
+		lockMock.mockRejectedValue(null);
+
+		await expect(
+			updateModelAccountPool("model", "set", ["one"]),
+		).rejects.toBe(null);
 	});
 });

--- a/test/config-lock-contention.test.ts
+++ b/test/config-lock-contention.test.ts
@@ -1,4 +1,12 @@
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
 import { promises as fs } from "node:fs";
 import { dirname, join } from "node:path";
 
@@ -25,9 +33,26 @@ describe("model account pool config lock contention", () => {
 		"openai-codex-auth-config.json",
 	);
 
+	const realPlatform = process.platform;
+
+	/**
+	 * The Windows branch of the contention classifier has to be exercised from
+	 * Linux CI too, so the platform is stubbed rather than the test skipped.
+	 */
+	function stubPlatform(platform: NodeJS.Platform): void {
+		Object.defineProperty(process, "platform", {
+			value: platform,
+			configurable: true,
+		});
+	}
+
 	beforeEach(async () => {
 		lockMock.mockReset();
 		await fs.rm(testHome, { recursive: true, force: true });
+	});
+
+	afterEach(() => {
+		stubPlatform(realPlatform);
 	});
 
 	afterAll(async () => {
@@ -43,7 +68,7 @@ describe("model account pool config lock contention", () => {
 		await expect(pending).rejects.toMatchObject({
 			name: "ConfigLockContentionError",
 			code: "CODEX_CONFIG_LOCK_CONTENTION",
-			path: `${testHome}/.opencode/openai-codex-auth-config.json`,
+			path: configPath,
 			cause,
 		});
 		await expect(pending).rejects.toBeInstanceOf(ConfigLockContentionError);
@@ -83,6 +108,87 @@ describe("model account pool config lock contention", () => {
 		expect(result.changed).toBe(true);
 		expect(result.previousAccountIds).toEqual([]);
 		expect(persisted.modelAccountPools.model).toEqual(["one"]);
+	});
+
+	it("keeps a successful mutation when releasing the lock fails", async () => {
+		// proper-lockfile rejects release() with ERELEASED when the lock was
+		// compromised mid-mutation, and removeLock propagates any non-ENOENT
+		// rmdir error. Before the fix that rejection escaped from the finally
+		// block and replaced the return value, so a change that had already
+		// reached disk was reported as a fatal lock error.
+		const releaseError = Object.assign(new Error("lock is already released"), {
+			code: "ERELEASED",
+		});
+		lockMock.mockResolvedValueOnce(async () => {
+			throw releaseError;
+		});
+
+		const result = await updateModelAccountPool("model", "set", ["one"]);
+		const persisted = JSON.parse(await fs.readFile(configPath, "utf8")) as {
+			modelAccountPools: Record<string, string[]>;
+		};
+
+		expect(result.changed).toBe(true);
+		expect(persisted.modelAccountPools.model).toEqual(["one"]);
+	});
+
+	it("installs an onCompromised handler that cannot kill the process", async () => {
+		// The proper-lockfile default rethrows from inside an fs callback, and
+		// nothing in this process installs an uncaughtException handler.
+		lockMock.mockResolvedValueOnce(async () => {});
+
+		await updateModelAccountPool("model", "set", ["one"]);
+
+		const options = lockMock.mock.calls[0]?.[1] as {
+			onCompromised?: (error: Error) => void;
+		};
+		expect(typeof options?.onCompromised).toBe("function");
+		expect(() =>
+			options.onCompromised?.(
+				Object.assign(new Error("lock compromised"), {
+					code: "ECOMPROMISED",
+				}),
+			),
+		).not.toThrow();
+	});
+
+	it("classifies Windows lock-directory failures as contention", async () => {
+		// On win32 a lock directory held open by another process (or by an
+		// antivirus scanner or the indexer) surfaces as EPERM/EBUSY, never
+		// EEXIST, so operation.mainError() is not ELOCKED and the degrade path
+		// used to be skipped entirely.
+		stubPlatform("win32");
+		const cause = Object.assign(new Error("operation not permitted"), {
+			code: "EPERM",
+		});
+		lockMock.mockRejectedValue(cause);
+
+		await expect(
+			updateModelAccountPool("model", "set", ["one"]),
+		).rejects.toBeInstanceOf(ConfigLockContentionError);
+	});
+
+	it("keeps EPERM fatal off Windows", async () => {
+		stubPlatform("linux");
+		const cause = Object.assign(new Error("operation not permitted"), {
+			code: "EPERM",
+		});
+		lockMock.mockRejectedValue(cause);
+
+		await expect(updateModelAccountPool("model", "set", ["one"])).rejects.toBe(
+			cause,
+		);
+	});
+
+	it("previews without acquiring the configuration lock", async () => {
+		// The one behaviour this branch actually changes for non-error callers:
+		// a dry run no longer contends for the config lock at all.
+		const result = await updateModelAccountPool("model", "set", ["one"], {
+			dryRun: true,
+		});
+
+		expect(lockMock).not.toHaveBeenCalled();
+		expect(result).toMatchObject({ dryRun: true, changed: true });
 	});
 
 	it("preserves malformed lock acquisition rejections", async () => {

--- a/test/config-lock-contention.test.ts
+++ b/test/config-lock-contention.test.ts
@@ -22,9 +22,14 @@ vi.mock("node:os", async () => {
 });
 
 import {
-	ConfigLockContentionError,
+	__resetLockContentionStateForTests,
 	updateModelAccountPool,
 } from "../lib/config.js";
+import {
+	CodexError,
+	ConfigError,
+	ConfigLockContentionError,
+} from "../lib/errors.js";
 
 describe("model account pool config lock contention", () => {
 	const configPath = join(
@@ -48,6 +53,7 @@ describe("model account pool config lock contention", () => {
 
 	beforeEach(async () => {
 		lockMock.mockReset();
+		__resetLockContentionStateForTests();
 		await fs.rm(testHome, { recursive: true, force: true });
 	});
 
@@ -189,6 +195,58 @@ describe("model account pool config lock contention", () => {
 
 		expect(lockMock).not.toHaveBeenCalled();
 		expect(result).toMatchObject({ dryRun: true, changed: true });
+	});
+
+	// ---------- finding 5: N contended callers must not cost N budgets ----------
+	it("drops to a probe budget once contention is established", async () => {
+		const cause = Object.assign(new Error("already held"), { code: "ELOCKED" });
+		lockMock.mockRejectedValue(cause);
+
+		await expect(
+			updateModelAccountPool("model", "set", ["one"]),
+		).rejects.toBeInstanceOf(ConfigLockContentionError);
+		await expect(
+			updateModelAccountPool("model", "set", ["two"]),
+		).rejects.toBeInstanceOf(ConfigLockContentionError);
+
+		const first = lockMock.mock.calls[0]?.[1] as { retries: { retries: number } };
+		const second = lockMock.mock.calls[1]?.[1] as { retries: { retries: number } };
+
+		expect(first.retries.retries).toBe(20);
+		// Every mutation is serialized behind the in-process queue, so without
+		// this the second caller would wait out another full budget against a
+		// holder the first caller already proved is external.
+		expect(second.retries.retries).toBeLessThan(first.retries.retries);
+	});
+
+	it("restores the full retry budget after a successful acquisition", async () => {
+		const cause = Object.assign(new Error("already held"), { code: "ELOCKED" });
+		lockMock.mockRejectedValueOnce(cause);
+		await expect(
+			updateModelAccountPool("model", "set", ["one"]),
+		).rejects.toBeInstanceOf(ConfigLockContentionError);
+
+		lockMock.mockResolvedValueOnce(async () => {});
+		await updateModelAccountPool("model", "set", ["two"]);
+
+		lockMock.mockRejectedValueOnce(cause);
+		await expect(
+			updateModelAccountPool("model", "set", ["three"]),
+		).rejects.toBeInstanceOf(ConfigLockContentionError);
+
+		const third = lockMock.mock.calls[2]?.[1] as { retries: { retries: number } };
+		expect(third.retries.retries).toBe(20);
+	});
+
+	// ---------- finding 11: transient, not "your configuration is wrong" ----------
+	it("is a transient error rather than a configuration error", () => {
+		const error = new ConfigLockContentionError("/tmp/config.json");
+
+		expect(error).toBeInstanceOf(CodexError);
+		expect(error.retryable).toBe(true);
+		// ConfigError means the user must go fix something; a handler catching it
+		// to stop retrying would give exactly the wrong advice here.
+		expect(error).not.toBeInstanceOf(ConfigError);
 	});
 
 	it("preserves malformed lock acquisition rejections", async () => {

--- a/test/model-pool-config.test.ts
+++ b/test/model-pool-config.test.ts
@@ -170,18 +170,12 @@ describe("model account pool config mutation", () => {
 		await expect(fs.stat(configPath)).rejects.toMatchObject({ code: "ENOENT" });
 	});
 
-	it("does not rewrite an unchanged pool", async () => {
+	it("does not rewrite a pool that is unchanged under the lock", async () => {
 		const original = `${JSON.stringify({
 			modelAccountPools: { model: ["one"] },
 		})}\n\n`;
 		await fs.writeFile(configPath, original);
-		const releaseForeignLock = await lock(configPath, { realpath: false });
-		let result: Awaited<ReturnType<typeof updateModelAccountPool>>;
-		try {
-			result = await updateModelAccountPool("model", "set", ["one"]);
-		} finally {
-			await releaseForeignLock();
-		}
+		const result = await updateModelAccountPool("model", "set", ["one"]);
 
 		expect(result.changed).toBe(false);
 		expect(await fs.readFile(configPath, "utf-8")).toBe(original);

--- a/test/model-pool-config.test.ts
+++ b/test/model-pool-config.test.ts
@@ -152,9 +152,15 @@ describe("model account pool config mutation", () => {
 	});
 
 	it("previews a change without creating or modifying the config file", async () => {
-		const result = await updateModelAccountPool("model", "set", ["one"], {
-			dryRun: true,
-		});
+		const releaseForeignLock = await lock(configPath, { realpath: false });
+		let result: Awaited<ReturnType<typeof updateModelAccountPool>>;
+		try {
+			result = await updateModelAccountPool("model", "set", ["one"], {
+				dryRun: true,
+			});
+		} finally {
+			await releaseForeignLock();
+		}
 
 		expect(result).toMatchObject({
 			accountIds: ["one"],
@@ -169,8 +175,13 @@ describe("model account pool config mutation", () => {
 			modelAccountPools: { model: ["one"] },
 		})}\n\n`;
 		await fs.writeFile(configPath, original);
-
-		const result = await updateModelAccountPool("model", "set", ["one"]);
+		const releaseForeignLock = await lock(configPath, { realpath: false });
+		let result: Awaited<ReturnType<typeof updateModelAccountPool>>;
+		try {
+			result = await updateModelAccountPool("model", "set", ["one"]);
+		} finally {
+			await releaseForeignLock();
+		}
 
 		expect(result.changed).toBe(false);
 		expect(await fs.readFile(configPath, "utf-8")).toBe(original);

--- a/test/model-pool-config.test.ts
+++ b/test/model-pool-config.test.ts
@@ -12,7 +12,10 @@ vi.mock("node:os", async () => {
 	return { ...actual, homedir: () => testHome };
 });
 
-import { updateModelAccountPool } from "../lib/config.js";
+import {
+	ConfigLockContentionError,
+	updateModelAccountPool,
+} from "../lib/config.js";
 
 const configDir = join(testHome, ".opencode");
 const configPath = join(configDir, "openai-codex-auth-config.json");
@@ -150,6 +153,34 @@ describe("model account pool config mutation", () => {
 			modelAccountPools: { model: ["one", "external", "two"] },
 		});
 	});
+
+	it(
+		"degrades to a contention error when a foreign lock outlasts the retry budget",
+		async () => {
+			// Deliberately unmocked. Every other contention test stubs
+			// proper-lockfile, so nothing else verifies the assumption the whole
+			// degrade path rests on: that an exhausted retry budget really does
+			// surface as code "ELOCKED".
+			await fs.writeFile(
+				configPath,
+				JSON.stringify({ modelAccountPools: { model: ["one"] } }),
+			);
+			const releaseForeignLock = await lock(configPath, { realpath: false });
+			try {
+				await expect(
+					updateModelAccountPool("model", "add", ["two"]),
+				).rejects.toBeInstanceOf(ConfigLockContentionError);
+			} finally {
+				await releaseForeignLock();
+			}
+
+			// The contended call must be a no-op, not a partial write.
+			expect(await readConfig()).toMatchObject({
+				modelAccountPools: { model: ["one"] },
+			});
+		},
+		20_000,
+	);
 
 	it("previews a change without creating or modifying the config file", async () => {
 		const releaseForeignLock = await lock(configPath, { realpath: false });

--- a/test/model-pool-config.test.ts
+++ b/test/model-pool-config.test.ts
@@ -12,10 +12,8 @@ vi.mock("node:os", async () => {
 	return { ...actual, homedir: () => testHome };
 });
 
-import {
-	ConfigLockContentionError,
-	updateModelAccountPool,
-} from "../lib/config.js";
+import { updateModelAccountPool } from "../lib/config.js";
+import { ConfigLockContentionError } from "../lib/errors.js";
 
 const configDir = join(testHome, ".opencode");
 const configPath = join(configDir, "openai-codex-auth-config.json");

--- a/test/storage-collision-warning.test.ts
+++ b/test/storage-collision-warning.test.ts
@@ -65,4 +65,63 @@ describe("account storage collision warning throttle", () => {
 
 		expect(warnMock).toHaveBeenCalledTimes(2);
 	});
+
+	it("warns separately for distinct storage paths", async () => {
+		await loadAccounts();
+		setStoragePathDirect(
+			"/tmp/oc-codex-collision-warning-other/accounts.json",
+		);
+
+		await loadAccounts();
+
+		expect(warnMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("warns separately for a new foreign lock generation", async () => {
+		await loadAccounts();
+		acquireOrDetectLockMock.mockResolvedValue({
+			acquired: false,
+			foreign: {
+				pid: 1234,
+				hostname: "other-host",
+				cwd: "/tmp/other-worktree",
+				startedAt: new Date(1).toISOString(),
+				lastActive: new Date(1).toISOString(),
+			},
+		});
+
+		await loadAccounts();
+
+		expect(warnMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("bounds remembered collision identities", async () => {
+		for (let pid = 1; pid <= 129; pid += 1) {
+			acquireOrDetectLockMock.mockResolvedValueOnce({
+				acquired: false,
+				foreign: {
+					pid,
+					hostname: "other-host",
+					cwd: "/tmp/other-worktree",
+					startedAt: new Date(0).toISOString(),
+					lastActive: new Date(0).toISOString(),
+				},
+			});
+			await loadAccounts();
+		}
+		acquireOrDetectLockMock.mockResolvedValueOnce({
+			acquired: false,
+			foreign: {
+				pid: 1,
+				hostname: "other-host",
+				cwd: "/tmp/other-worktree",
+				startedAt: new Date(0).toISOString(),
+				lastActive: new Date(0).toISOString(),
+			},
+		});
+
+		await loadAccounts();
+
+		expect(warnMock).toHaveBeenCalledTimes(130);
+	});
 });

--- a/test/storage-collision-warning.test.ts
+++ b/test/storage-collision-warning.test.ts
@@ -89,49 +89,57 @@ describe("account storage collision warning throttle", () => {
 		expect(collisionWarnCount()).toBe(2);
 	});
 
-	it("warns separately for a new foreign lock generation", async () => {
+	it("keeps throttling when the foreign holder restarts", async () => {
+		// The throttle used to key on the foreign pid and startedAt, so a peer
+		// that restarted - or a series of short-lived sessions - produced a fresh
+		// identity on every probe and defeated the throttle entirely.
 		await loadAccounts();
-		acquireOrDetectLockMock.mockResolvedValue({
-			acquired: false,
-			foreign: {
-				pid: 1234,
-				hostname: "other-host",
-				cwd: "/tmp/other-worktree",
-				startedAt: new Date(1).toISOString(),
-				lastActive: new Date(1).toISOString(),
-			},
+		for (const [pid, startedAt] of [
+			[4321, 1],
+			[5678, 2],
+			[9012, 3],
+		] as const) {
+			acquireOrDetectLockMock.mockResolvedValue({
+				acquired: false,
+				foreign: {
+					pid,
+					hostname: "other-host",
+					cwd: "/tmp/other-worktree",
+					startedAt: new Date(startedAt).toISOString(),
+					lastActive: new Date(startedAt).toISOString(),
+				},
+			});
+			await loadAccounts();
+		}
+
+		expect(collisionWarnCount()).toBe(1);
+	});
+
+	it("does not record a warning the logger failed to emit", async () => {
+		// shouldWarnForCollision used to record the warn before the caller emitted
+		// it, so a throwing logger silently suppressed the next 60s of collisions.
+		warnMock.mockImplementationOnce(() => {
+			throw new Error("transport down");
 		});
 
+		await loadAccounts();
 		await loadAccounts();
 
 		expect(collisionWarnCount()).toBe(2);
 	});
 
 	it("bounds remembered collision identities", async () => {
-		for (let pid = 1; pid <= 129; pid += 1) {
-			acquireOrDetectLockMock.mockResolvedValueOnce({
-				acquired: false,
-				foreign: {
-					pid,
-					hostname: "other-host",
-					cwd: "/tmp/other-worktree",
-					startedAt: new Date(0).toISOString(),
-					lastActive: new Date(0).toISOString(),
-				},
-			});
+		// Identities are (storage path, host) pairs, so distinct paths are what
+		// fills the map - a single peer cycling pids no longer can.
+		const pathFor = (index: number) =>
+			`/tmp/oc-codex-collision-warning-${index}/accounts.json`;
+		for (let index = 1; index <= 129; index += 1) {
+			setStoragePathDirect(pathFor(index));
 			await loadAccounts();
 		}
-		acquireOrDetectLockMock.mockResolvedValueOnce({
-			acquired: false,
-			foreign: {
-				pid: 1,
-				hostname: "other-host",
-				cwd: "/tmp/other-worktree",
-				startedAt: new Date(0).toISOString(),
-				lastActive: new Date(0).toISOString(),
-			},
-		});
 
+		// The first identity has been evicted, so it warns again.
+		setStoragePathDirect(pathFor(1));
 		await loadAccounts();
 
 		expect(collisionWarnCount()).toBe(130);

--- a/test/storage-collision-warning.test.ts
+++ b/test/storage-collision-warning.test.ts
@@ -29,6 +29,18 @@ import {
 } from "../lib/storage/load-save.js";
 import { setStoragePathDirect } from "../lib/storage/state.js";
 
+const COLLISION_MESSAGE = "Multi-worktree collision detected on account storage";
+
+/**
+ * loadAccounts() warns from several unrelated sites (schema validation, global
+ * fallback load failures). Counting every warn would fail this suite the moment
+ * any of them fires, so only the collision warning is counted.
+ */
+function collisionWarnCount(): number {
+	return warnMock.mock.calls.filter((call) => call[0] === COLLISION_MESSAGE)
+		.length;
+}
+
 describe("account storage collision warning throttle", () => {
 	beforeEach(() => {
 		vi.useFakeTimers();
@@ -58,12 +70,12 @@ describe("account storage collision warning throttle", () => {
 		await loadAccounts();
 		await loadAccounts();
 
-		expect(warnMock).toHaveBeenCalledTimes(1);
+		expect(collisionWarnCount()).toBe(1);
 
 		vi.advanceTimersByTime(60_000);
 		await loadAccounts();
 
-		expect(warnMock).toHaveBeenCalledTimes(2);
+		expect(collisionWarnCount()).toBe(2);
 	});
 
 	it("warns separately for distinct storage paths", async () => {
@@ -74,7 +86,7 @@ describe("account storage collision warning throttle", () => {
 
 		await loadAccounts();
 
-		expect(warnMock).toHaveBeenCalledTimes(2);
+		expect(collisionWarnCount()).toBe(2);
 	});
 
 	it("warns separately for a new foreign lock generation", async () => {
@@ -92,7 +104,7 @@ describe("account storage collision warning throttle", () => {
 
 		await loadAccounts();
 
-		expect(warnMock).toHaveBeenCalledTimes(2);
+		expect(collisionWarnCount()).toBe(2);
 	});
 
 	it("bounds remembered collision identities", async () => {
@@ -122,6 +134,6 @@ describe("account storage collision warning throttle", () => {
 
 		await loadAccounts();
 
-		expect(warnMock).toHaveBeenCalledTimes(130);
+		expect(collisionWarnCount()).toBe(130);
 	});
 });

--- a/test/storage-collision-warning.test.ts
+++ b/test/storage-collision-warning.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { acquireOrDetectLockMock, warnMock } = vi.hoisted(() => ({
+	acquireOrDetectLockMock: vi.fn(),
+	warnMock: vi.fn(),
+}));
+
+vi.mock("../lib/logger.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/logger.js")>();
+	return {
+		...actual,
+		createLogger: () => ({
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: warnMock,
+			error: vi.fn(),
+			time: vi.fn(),
+			timeEnd: vi.fn(),
+		}),
+	};
+});
+vi.mock("../lib/storage/worktree-lock.js", () => ({
+	acquireOrDetectLock: acquireOrDetectLockMock,
+}));
+
+import {
+	__resetCollisionWarningThrottleForTests,
+	loadAccounts,
+} from "../lib/storage/load-save.js";
+import { setStoragePathDirect } from "../lib/storage/state.js";
+
+describe("account storage collision warning throttle", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+		warnMock.mockReset();
+		acquireOrDetectLockMock.mockReset();
+		acquireOrDetectLockMock.mockResolvedValue({
+			acquired: false,
+			foreign: {
+				pid: 1234,
+				hostname: "other-host",
+				cwd: "/tmp/other-worktree",
+				startedAt: new Date(0).toISOString(),
+				lastActive: new Date(0).toISOString(),
+			},
+		});
+		setStoragePathDirect("/tmp/oc-codex-collision-warning/accounts.json");
+		__resetCollisionWarningThrottleForTests();
+	});
+
+	afterEach(() => {
+		setStoragePathDirect(null);
+		vi.useRealTimers();
+	});
+
+	it("warns once per throttle window", async () => {
+		await loadAccounts();
+		await loadAccounts();
+
+		expect(warnMock).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(60_000);
+		await loadAccounts();
+
+		expect(warnMock).toHaveBeenCalledTimes(2);
+	});
+});

--- a/test/tools-codex-pool.test.ts
+++ b/test/tools-codex-pool.test.ts
@@ -8,15 +8,23 @@ vi.mock("../lib/storage.js", () => ({
 	loadAccounts: vi.fn(),
 }));
 
-vi.mock("../lib/config.js", () => ({
-	getModelAccountPoolMode: vi.fn((config, model) =>
-		config.modelAccountPoolModes?.[model] ?? "preferred",
-	),
-	loadPluginConfig: vi.fn(),
-	updateModelAccountPool: vi.fn(),
-}));
+vi.mock("../lib/config.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/config.js")>();
+	return {
+		...actual,
+		getModelAccountPoolMode: vi.fn((config, model) =>
+			config.modelAccountPoolModes?.[model] ?? "preferred",
+		),
+		loadPluginConfig: vi.fn(),
+		updateModelAccountPool: vi.fn(),
+	};
+});
 
-import { loadPluginConfig, updateModelAccountPool } from "../lib/config.js";
+import {
+	ConfigLockContentionError,
+	loadPluginConfig,
+	updateModelAccountPool,
+} from "../lib/config.js";
 import { loadAccounts } from "../lib/storage.js";
 
 const storage: AccountStorageV3 = {
@@ -54,7 +62,10 @@ function buildCtx(): ToolContext {
 				? { accountId: options.account?.accountId ?? null }
 				: {}),
 		}),
-	} as unknown as ToolContext;
+	} satisfies Pick<
+		ToolContext,
+		"resolveMaskEmail" | "formatCommandAccountLabel" | "buildJsonAccountIdentity"
+	> as unknown as ToolContext;
 }
 
 describe("codex-pool tool", () => {
@@ -249,5 +260,56 @@ describe("codex-pool tool", () => {
 				{} as never,
 			),
 		).rejects.toThrow("has no stable account ID");
+	});
+
+	it("returns retry guidance when configuration lock acquisition is exhausted", async () => {
+		vi.mocked(updateModelAccountPool).mockRejectedValue(
+			new ConfigLockContentionError("/tmp/config.json"),
+		);
+
+		const output = await createCodexPoolTool(buildCtx()).execute(
+			{ action: "set", model: "gpt-5.6-sol", accounts: [1] },
+			{} as never,
+		);
+
+		expect(output).toContain("locked by another process");
+		expect(output).toContain("No change was made");
+	});
+
+	it("returns structured retryable lock contention in JSON", async () => {
+		vi.mocked(updateModelAccountPool).mockRejectedValue(
+			new ConfigLockContentionError("/tmp/config.json"),
+		);
+
+		const output = await createCodexPoolTool(buildCtx()).execute(
+			{
+				action: "set",
+				model: "gpt-5.6-sol",
+				accounts: [1],
+				format: "json",
+			},
+			{} as never,
+		);
+		const parsed = JSON.parse(output as string) as Record<string, unknown>;
+
+		expect(parsed).toMatchObject({
+			action: "set",
+			model: "gpt-5.6-sol",
+			changed: false,
+			applied: false,
+			error: "config_locked",
+			retryable: true,
+		});
+	});
+
+	it("rethrows non-contention persistence failures", async () => {
+		vi.mocked(updateModelAccountPool).mockRejectedValue(new Error("disk failed"));
+
+		await expect(
+			createCodexPoolTool(buildCtx()).execute(
+				{ action: "set", model: "gpt-5.6-sol", accounts: [1] },
+				{} as never,
+			),
+		).rejects.toThrow("disk failed");
 	});
 });

--- a/test/tools-codex-pool.test.ts
+++ b/test/tools-codex-pool.test.ts
@@ -20,11 +20,8 @@ vi.mock("../lib/config.js", async (importOriginal) => {
 	};
 });
 
-import {
-	ConfigLockContentionError,
-	loadPluginConfig,
-	updateModelAccountPool,
-} from "../lib/config.js";
+import { loadPluginConfig, updateModelAccountPool } from "../lib/config.js";
+import { ConfigLockContentionError } from "../lib/errors.js";
 import { loadAccounts } from "../lib/storage.js";
 
 const storage: AccountStorageV3 = {
@@ -297,9 +294,55 @@ describe("codex-pool tool", () => {
 			model: "gpt-5.6-sol",
 			changed: false,
 			applied: false,
-			error: "config_locked",
+			dryRun: false,
+			restartRequired: false,
+			// Nothing was mutated, so the payload reports the pool still on disk.
+			previousConfiguredCount: 2,
+			previousPoolMode: "strict",
+			// Same token as the class name and the ErrorCode used in logs, so a
+			// caller that greps for what it saw in tool JSON finds something.
+			error: "CODEX_CONFIG_LOCK_CONTENTION",
 			retryable: true,
 		});
+		expect(parsed.pool).toMatchObject({ poolMode: "strict" });
+	});
+
+	// ---------- finding 4: the degrade path must not break strict consumers ----------
+	it("keeps the contention payload shape identical to a successful mutation", async () => {
+		vi.mocked(updateModelAccountPool).mockResolvedValue({
+			model: "gpt-5.6-sol",
+			accountIds: ["account-one"],
+			changed: true,
+			dryRun: false,
+			previousAccountIds: ["account-one", "missing-account"],
+			previousPoolMode: "strict",
+			poolMode: "strict",
+		});
+		const okPayload = JSON.parse(
+			(await createCodexPoolTool(buildCtx()).execute(
+				{ action: "set", model: "gpt-5.6-sol", accounts: [1], format: "json" },
+				{} as never,
+			)) as string,
+		) as Record<string, unknown>;
+
+		vi.mocked(updateModelAccountPool).mockRejectedValue(
+			new ConfigLockContentionError("/tmp/config.json"),
+		);
+		const lockedPayload = JSON.parse(
+			(await createCodexPoolTool(buildCtx()).execute(
+				{ action: "set", model: "gpt-5.6-sol", accounts: [1], format: "json" },
+				{} as never,
+			)) as string,
+		) as Record<string, unknown>;
+
+		// A consumer reading parsed.pool.accounts must not start throwing just
+		// because the tool degraded.
+		expect(Object.keys(lockedPayload)).toEqual(
+			expect.arrayContaining(Object.keys(okPayload)),
+		);
+		expect(Array.isArray((lockedPayload.pool as { accounts?: unknown }).accounts)).toBe(
+			true,
+		);
 	});
 
 	it("rethrows non-contention persistence failures", async () => {


### PR DESCRIPTION
Closes out the eight review findings left open on #225.

> [!IMPORTANT]
> **This branch is stacked on #225.** It branches from `fix/config-lock-contention`, so the diff against `main` shown here includes #225's eight commits. Merge #225 first and this narrows to its own commit — or merge this one and you get both. Only `5da8a52` is new here.

#225 fixed lock **acquisition** and **release**. The findings below are the ones it left: the stall, the degrade payload, and the identifiers around them.

## The one that matters: the stall is half of #224

`modelAccountPoolMutationQueue` serializes every in-process mutation, and each queued caller independently waited out the full ~3s retry budget against **the same** foreign holder. Ten parallel `codex-pool` calls blocked for ten times the budget and then all failed anyway — that is the "afterwards it completely stalls the sub tasks" half of the report, and #225 made it marginally worse by raising the budget.

Once one call establishes that the lock is externally held, callers within the next second use a short probe budget and degrade immediately. Any successful acquisition restores the full budget, so an isolated collision still gets the patient path.

Also reverts the 20→22 / 200→225ms bump. It moved the worst case under 20%, which cannot convert a real multi-process collision into a success, and taxed every contended call.

## The degrade path was breaking consumers

The contention JSON dropped `pool`, `dryRun`, `restartRequired`, `previousConfiguredCount` and `previousPoolMode`, so a caller reading `parsed.pool.accounts` got a `TypeError` — a **harder** failure than the raw ELOCKED it replaced. Nothing was mutated, so it now reports the pool still on disk, in the success payload's shape.

It also emitted `error: "config_locked"` while the class was `ConfigLockContentionError` and the code was `CODEX_CONFIG_LOCK_CONTENTION`. Three spellings of one condition meant nothing seen in tool JSON could be found by grepping the codebase or the logs. Now emits `ErrorCode.CONFIG_LOCK_CONTENTION`.

## Wrong error family

`ConfigLockContentionError extends ConfigError`, whose doc comment scopes it to non-retryable bad user configuration ("missing TTY, malformed CLI input, bad format flags"). Any `instanceof ConfigError` handler would tell the user to go fix their config for a condition that resolves on its own. Now extends `CodexError` with `retryable: true`, matching `CodexNetworkError`.

## The collision throttle never actually throttled

The key was `(path, host, pid, startedAt)`. A foreign holder that restarts — or a series of short-lived sessions — produced a brand new key on every probe, so the throttle never fired and the log spam it exists to suppress continued unabated. Those dead identities also evicted live ones from the 128-entry FIFO. Now keyed on `(path, host)`.

Separately, `shouldWarnForCollision` was a predicate that recorded the warning as delivered **before** the caller emitted it, so a `log.warn` that threw silently suppressed the next 60s of collisions. Split into a pure check and a record step, with the record after the emit.

## Import indirection

`ConfigLockContentionError` was imported *and* re-exported in the middle of `lib/config.ts`'s import block, and `codex-pool.ts` did its `instanceof` check against that re-exported binding. Now imported from `lib/errors.js` directly; `lib/config.js` is not a public entry point (only `dist/index.js` and `dist/tui.js` are), so nothing external breaks.

## Tests

Every fix is pinned by a test **verified to fail when that fix alone is reverted** — I reverted each hunk individually and confirmed the corresponding test goes red:

| Finding | Test | Reverted alone → |
|---|---|---|
| stall | `drops to a probe budget once contention is established` | fails |
| error family | `is a transient error rather than a configuration error` | fails |
| throttle key | `keeps throttling when the foreign holder restarts` | fails |
| record-after-emit | `does not record a warning the logger failed to emit` | fails |
| payload + code | `returns structured retryable lock contention in JSON` | fails |

Plus `keeps the contention payload shape identical to a successful mutation`, which compares the degraded payload's key set against a real success payload rather than hardcoding one.

The two collision-throttle tests that asserted per-pid warning encoded the behaviour this corrects, so they are rewritten rather than deleted. The FIFO bound is now exercised with distinct storage paths — which is what the key actually is.

## Verification

- `npm run typecheck` — clean
- `npx eslint lib test --ext .ts` — clean
- `npm test` — **117 files, 2954 passed, 1 skipped, 0 failed**

Windows only; Linux/non-root not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---

<h3>Greptile Summary</h3>

this pr adds cross-process locking and bounded contention behavior for model-pool config mutations, aligns contention errors and tool payloads, and throttles storage-collision warnings.
- adds full and probe retry budgets around serialized config mutations, including windows filesystem error handling
- returns shape-compatible retryable contention output from codex-pool
- changes collision-warning throttling to storage path plus foreign host
- adds vitest coverage for contention, payload compatibility, and warning throttling

<h3>Confidence Score: 4/5</h3>

the pr should not merge until a compromised config lock stops the mutation from continuing without cross-process exclusivity.

the new compromise callback avoids a process crash but allows concurrent config writers to overlap, creating a concrete lost-update path; the troubleshooting throttle description also needs a non-blocking correction.

**Files Needing Attention:** lib/config.ts, docs/troubleshooting.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| lib/config.ts | adds lock retry and compromise handling, but continuing after compromise permits a cross-process lost-update race. |
| lib/tools/codex-pool.ts | maps typed contention into a retryable, success-shape-compatible tool response without exposing tokens. |
| lib/storage/load-save.ts | throttles collision warnings by storage path and host and records only successfully emitted warnings. |
| lib/errors.ts | adds a transient typed contention error outside the non-retryable configuration-error family. |
| docs/troubleshooting.md | documents lock contention and collision warnings, but the stated lock-generation throttle scope no longer matches the implementation. |
| test/config-lock-contention.test.ts | covers retry budgets and windows classification but lacks a concurrent compromise test that would expose lost writes. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as process a
  participant L as config lock
  participant B as process b
  participant F as config file
  A->>L: acquire lock
  L-->>A: acquired
  L-->>A: onCompromised
  B->>L: reclaim and acquire
  A->>F: read config despite compromise
  B->>F: read, mutate, write
  A->>F: write stale mutation
  Note over A,F: process b's update can be lost
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fconfig-lock-contention-followups%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fconfig-lock-contention-followups%22.%0A%0A%23%23%23%20Issue%201%0Alib%2Fconfig.ts%3A272-276%0A**compromised%20lock%20permits%20lost%20updates**%0A%0Aif%20another%20process%20reclaims%20the%20config%20lock%20during%20a%20mutation%2C%20%60onCompromised%60%20only%20logs%20and%20the%20original%20process%20continues%20its%20read-modify-write%20without%20cross-process%20exclusivity%2C%20causing%20either%20process's%20config%20update%20to%20be%20silently%20overwritten.%0A%0A%23%23%23%20Issue%202%0Adocs%2Ftroubleshooting.md%3A161%0A**throttle%20scope%20is%20documented%20incorrectly**%0A%0Athis%20says%20warnings%20are%20throttled%20per%20foreign%20lock%20generation%2C%20but%20the%20changed%20key%20uses%20only%20storage%20path%20and%20hostname.%20after%20a%20foreign%20process%20restarts%2C%20its%20warning%20remains%20suppressed%20within%20the%20existing%20one-minute%20host%2Fpath%20window%2C%20so%20the%20troubleshooting%20guidance%20should%20describe%20that%20behavior.%0A%0A%60%60%60suggestion%0AThis%20advisory%20warning%20means%20another%20live%20process%20or%20host%20is%20using%20the%20same%20account-storage%20file.%20It%20includes%20the%20foreign%20and%20local%20PID%2C%20host%2C%20and%20working%20directory%20so%20you%20can%20identify%20the%20sessions.%20Reads%20and%20writes%20continue%20because%20the%20worktree%20lock%20is%20intentionally%20advisory%3B%20repeated%20warnings%20are%20throttled%20to%20once%20per%20minute%20for%20each%20storage%20path%20and%20foreign%20host.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ndycode%2Foc-codex-multi-auth&pr=228&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/config.ts:272-276
**compromised lock permits lost updates**

if another process reclaims the config lock during a mutation, `onCompromised` only logs and the original process continues its read-modify-write without cross-process exclusivity, causing either process's config update to be silently overwritten.

### Issue 2
docs/troubleshooting.md:161
**throttle scope is documented incorrectly**

this says warnings are throttled per foreign lock generation, but the changed key uses only storage path and hostname. after a foreign process restarts, its warning remains suppressed within the existing one-minute host/path window, so the troubleshooting guidance should describe that behavior.

```suggestion
This advisory warning means another live process or host is using the same account-storage file. It includes the foreign and local PID, host, and working directory so you can identify the sessions. Reads and writes continue because the worktree lock is intentionally advisory; repeated warnings are throttled to once per minute for each storage path and foreign host.
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(config): bound contention stall and ..."](https://github.com/ndycode/oc-codex-multi-auth/commit/5da8a52c91957fef45c093e00fe29f2e388efeea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52255701)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Context used - speak in lowercase, concise sentences. act like th... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))
- Knowledge Base — [Config, Schemas, and Shared Primitives](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/config-schemas.md)
- Knowledge Base — [Account Storage Layer](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/storage.md)
- Knowledge Base — [Tools and CLI](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/tools-cli.md)
</details>

<!-- /greptile_comment -->