### PR TITLE
fix(routing): report real account counts when a model pool is exhausted

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -128,7 +128,11 @@ import {
         parseRateLimitReason,
 	lookupCodexCliTokensByEmail,
 } from "./lib/accounts.js";
-import { matchesModelPoolAccountKey } from "./lib/accounts/pool-identity.js";
+import {
+	getModelPoolAccountKey,
+	matchesModelPoolAccountKey,
+	type ModelPoolAccount,
+} from "./lib/accounts/pool-identity.js";
 import { resolveDisplayEmail } from "./lib/account-display.js";
 import { CodexAuthError } from "./lib/errors.js";
 import {
@@ -283,6 +287,47 @@ function isLoopbackGatewayHost(hostname: string): boolean {
 		return Number.parseInt(mapped[1], 16) >>> 8 === 0x7f;
 	}
 	return LOOPBACK_GATEWAY_HOSTS.has(hostname);
+}
+
+/**
+ * Stable per-account identity for the terminal-error diagnostics counters.
+ *
+ * `account.index` is not usable here: `AccountManager.removeAccount` reindexes
+ * the survivors, so an index recorded before a mid-traversal removal silently
+ * refers to a different account afterwards. The model-pool identity survives
+ * that reindex; the refresh token is the last-resort fallback for records that
+ * have not resolved an account id yet.
+ */
+function getAccountDiagnosticsKey(
+	account: ModelPoolAccount & { refreshToken: string },
+): string {
+	return getModelPoolAccountKey(account) ?? `refresh:${account.refreshToken}`;
+}
+
+/**
+ * How many live accounts the configured pool keys actually resolve to.
+ *
+ * Pool keys and accounts are not 1:1 — a legacy `accountId` key matches every
+ * Business seat in that workspace, and two keys can resolve to the same seat —
+ * so pool size must be counted over accounts, never over `poolKeys.length`.
+ */
+function countResolvedPoolAccounts(
+	accounts: readonly ModelPoolAccount[],
+	poolKeys: readonly string[],
+): number {
+	return accounts.filter((account) =>
+		poolKeys.some((key) => matchesModelPoolAccountKey(account, key)),
+	).length;
+}
+
+/** Configured pool keys matching no live account (typo, or account removed). */
+function countUnresolvedPoolKeys(
+	accounts: readonly ModelPoolAccount[],
+	poolKeys: readonly string[],
+): number {
+	return poolKeys.filter(
+		(key) => !accounts.some((account) => matchesModelPoolAccountKey(account, key)),
+	).length;
 }
 
 function invalidBaseURL(reason: string): Error {
@@ -2197,8 +2242,13 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 							while (true) {
 						let accountCount = accountManager.getAccountCount();
 						const attempted = new Set<number>();
-						const requestedAccountIndices = new Set<number>();
-						const unsupportedAccountIndices = new Set<number>();
+						// Diagnostics for the terminal error message below. Keyed on a stable
+						// account identity, not `account.index`, so the two `attempted.clear()`
+						// sites that follow a mid-traversal account removal cannot desync them.
+						// Deliberately scoped to this traversal: a fallback restart re-enters
+						// the loop with a different model, and the message names that model.
+						const fetchedAccountKeys = new Set<string>();
+						const unsupportedAccountKeys = new Set<string>();
 						let restartAccountTraversalWithFallback = false;
 						let restartAccountTraversalAfterWorkspaceDeactivation = false;
 						const preferredAccountIds = getModelAccountPool(pluginConfig, model);
@@ -2540,7 +2590,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 								// in-memory only and run on Node's single-threaded event loop, so no
 								// filesystem locking or token-redaction concerns are introduced here.
 								runtimeMetrics.totalRequests++;
-								requestedAccountIndices.add(account.index);
+								fetchedAccountKeys.add(getAccountDiagnosticsKey(account));
 								response = await fetch(url, {
 									...requestInit,
 									headers,
@@ -2738,7 +2788,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 
 			const unsupportedModelInfo = getUnsupportedCodexModelInfo(errorBody);
 			if (unsupportedModelInfo.isUnsupported) {
-				unsupportedAccountIndices.add(account.index);
+				unsupportedAccountKeys.add(getAccountDiagnosticsKey(account));
 			}
 			const hasRemainingAccounts = attempted.size < Math.max(1, accountCount);
 
@@ -3234,6 +3284,12 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 							continue;
 						}
 
+						// Shared by both terminal messages below: how many distinct accounts
+						// this traversal actually sent upstream, and how many of those the
+						// backend rejected as not entitled to the model.
+						const attemptedCount = fetchedAccountKeys.size;
+						const unsupportedCount = unsupportedAccountKeys.size;
+
 						if (strictAccountPool) {
 							const poolWaitMs = accountManager.getMinWaitTimeForFamily(
 								modelFamily,
@@ -3241,11 +3297,18 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 								preferredAccountIds,
 							);
 							const effectiveModel = model ?? requestedModel ?? "requested model";
-							const attemptedCount = requestedAccountIndices.size;
-							const unsupportedCount = unsupportedAccountIndices.size;
+							const poolAccounts = accountManager.getAccountsSnapshot();
+							const poolAccountCount = countResolvedPoolAccounts(
+								poolAccounts,
+								preferredAccountIds,
+							);
+							const unresolvedKeyCount = countUnresolvedPoolKeys(
+								poolAccounts,
+								preferredAccountIds,
+							);
 							const unavailableCount = Math.max(
 								0,
-								preferredAccountIds.length - attemptedCount,
+								poolAccountCount - attemptedCount,
 							);
 							const waitDetail =
 								poolWaitMs > 0
@@ -3256,14 +3319,20 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 									? ` The model was unsupported on ${unsupportedCount} of ${attemptedCount} attempted pooled account(s).`
 									: attemptedCount > 0
 										? ` ${attemptedCount} pooled account(s) were attempted without success.`
+										: "";
+							const unresolvedDetail =
+								unresolvedKeyCount > 0
+									? ` ${unresolvedKeyCount} configured pool key(s) matched no known account.`
 									: "";
 							const unavailableDetail =
 								unavailableCount > 0
-									? ` ${unavailableCount} configured pool account(s) were unavailable or unresolved.`
+									? ` ${unavailableCount} pooled account(s) were never attempted (rate-limited, cooling down, or disabled).`
 									: "";
 							const message =
-								`Strict account pool unavailable for ${effectiveModel}.` +
+								`Strict account pool unavailable for ${effectiveModel}. ` +
+								`${preferredAccountIds.length} configured pool key(s) resolved to ${poolAccountCount} account(s).` +
 								attemptDetail +
+								unresolvedDetail +
 								unavailableDetail +
 								waitDetail;
 							if (runtimeMetrics.lastSelectionSnapshot) {
@@ -3293,8 +3362,6 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 
 								const waitMs = accountManager.getMinWaitTimeForFamily(modelFamily, model);
 								const count = accountManager.getAccountCount();
-								const attemptedCount = requestedAccountIndices.size;
-								const unsupportedCount = unsupportedAccountIndices.size;
 								const unavailableCount = Math.max(0, count - attemptedCount);
 
 								if (
@@ -3316,7 +3383,12 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 								}
 
 								const waitLabel = waitMs > 0 ? formatWaitTime(waitMs) : "a bit";
+								// `runtimeMetrics` is plugin-scoped, so `lastErrorCategory` alone
+								// can still hold "unsupported-model" from an *earlier* request.
+								// Require an unsupported response from this traversal as well, or
+								// a request that never reached an account renders "0 of 0".
 								const wasEntitlementExhaustion =
+									unsupportedCount > 0 &&
 									runtimeMetrics.lastErrorCategory === "unsupported-model";
 								const entitlementModel =
 									typeof runtimeMetrics.lastError === "string"
@@ -3335,7 +3407,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 										: waitMs > 0
 											? `All ${count} account(s) are rate-limited. Try again in ${waitLabel} or add another account with \`opencode auth login\`.`
 											: wasEntitlementExhaustion
-												? `No selectable account succeeded for the requested model.${entitlementDetail} Codex model access is account/workspace gated; default gpt-5.6-sol/terra/luna selectors auto-fallback down the 5.6 tiers to gpt-5.5, and gpt-5.5/gpt-5-codex through the GPT-5.4 family when possible. Set \`unsupportedCodexPolicy: "fallback"\` for the full manual fallback chain, or see \`codex-health\` for per-account details.`
+												? `No selectable account succeeded for the requested model across ${count} configured account(s).${entitlementDetail} Codex model access is account/workspace gated; default gpt-5.6-sol/terra/luna selectors auto-fallback down the 5.6 tiers to gpt-5.5, and gpt-5.5/gpt-5-codex through the GPT-5.4 family when possible. Set \`unsupportedCodexPolicy: "fallback"\` for the full manual fallback chain, or see \`codex-health\` for per-account details.`
 												: `All ${count} account(s) failed (server errors or auth issues). Check account health with \`codex-health\`.`;
 								runtimeMetrics.failedRequests++;
 								runtimeMetrics.lastError = message;

--- a/index.ts
+++ b/index.ts
@@ -2197,6 +2197,8 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 							while (true) {
 						let accountCount = accountManager.getAccountCount();
 						const attempted = new Set<number>();
+						const requestedAccountIndices = new Set<number>();
+						const unsupportedAccountIndices = new Set<number>();
 						let restartAccountTraversalWithFallback = false;
 						let restartAccountTraversalAfterWorkspaceDeactivation = false;
 						const preferredAccountIds = getModelAccountPool(pluginConfig, model);
@@ -2538,6 +2540,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 								// in-memory only and run on Node's single-threaded event loop, so no
 								// filesystem locking or token-redaction concerns are introduced here.
 								runtimeMetrics.totalRequests++;
+								requestedAccountIndices.add(account.index);
 								response = await fetch(url, {
 									...requestInit,
 									headers,
@@ -2734,6 +2737,9 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 				}
 
 			const unsupportedModelInfo = getUnsupportedCodexModelInfo(errorBody);
+			if (unsupportedModelInfo.isUnsupported) {
+				unsupportedAccountIndices.add(account.index);
+			}
 			const hasRemainingAccounts = attempted.size < Math.max(1, accountCount);
 
 			// Entitlements can differ by account/workspace, so try remaining
@@ -3235,13 +3241,30 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 								preferredAccountIds,
 							);
 							const effectiveModel = model ?? requestedModel ?? "requested model";
+							const attemptedCount = requestedAccountIndices.size;
+							const unsupportedCount = unsupportedAccountIndices.size;
+							const unavailableCount = Math.max(
+								0,
+								preferredAccountIds.length - attemptedCount,
+							);
 							const waitDetail =
 								poolWaitMs > 0
 									? ` Try again in ${formatWaitTime(poolWaitMs)}.`
 									: " Check the pooled accounts with `codex-health`.";
+							const attemptDetail =
+								unsupportedCount > 0
+									? ` The model was unsupported on ${unsupportedCount} of ${attemptedCount} attempted pooled account(s).`
+									: attemptedCount > 0
+										? ` ${attemptedCount} pooled account(s) were attempted without success.`
+									: "";
+							const unavailableDetail =
+								unavailableCount > 0
+									? ` ${unavailableCount} configured pool account(s) were unavailable or unresolved.`
+									: "";
 							const message =
-								`Strict account pool unavailable for ${effectiveModel}. ` +
-								`None of its ${preferredAccountIds.length} configured account(s) is selectable.` +
+								`Strict account pool unavailable for ${effectiveModel}.` +
+								attemptDetail +
+								unavailableDetail +
 								waitDetail;
 							if (runtimeMetrics.lastSelectionSnapshot) {
 								runtimeMetrics.lastSelectionSnapshot = {
@@ -3268,8 +3291,11 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 							);
 						}
 
-										const waitMs = accountManager.getMinWaitTimeForFamily(modelFamily, model);
-										const count = accountManager.getAccountCount();
+								const waitMs = accountManager.getMinWaitTimeForFamily(modelFamily, model);
+								const count = accountManager.getAccountCount();
+								const attemptedCount = requestedAccountIndices.size;
+								const unsupportedCount = unsupportedAccountIndices.size;
+								const unavailableCount = Math.max(0, count - attemptedCount);
 
 								if (
 									retryAllAccountsRateLimited &&
@@ -3301,7 +3327,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 										: "";
 								const entitlementDetail =
 									entitlementModel.length > 0
-										? ` The backend rejected '${entitlementModel}' as not entitled for Codex OAuth on every pooled account.`
+										? ` The backend rejected '${entitlementModel}' as not entitled for Codex OAuth on ${unsupportedCount} of ${attemptedCount} attempted account(s).${unavailableCount > 0 ? ` ${unavailableCount} configured account(s) were unavailable or excluded.` : ""}`
 										: "";
 								const message =
 									count === 0
@@ -3309,7 +3335,7 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 										: waitMs > 0
 											? `All ${count} account(s) are rate-limited. Try again in ${waitLabel} or add another account with \`opencode auth login\`.`
 											: wasEntitlementExhaustion
-												? `All ${count} account(s) returned 'model not supported' for the requested model.${entitlementDetail} Codex model access is account/workspace gated; default gpt-5.6-sol/terra/luna selectors auto-fallback down the 5.6 tiers to gpt-5.5, and gpt-5.5/gpt-5-codex through the GPT-5.4 family when possible. Set \`unsupportedCodexPolicy: "fallback"\` for the full manual fallback chain, or see \`codex-health\` for per-account details.`
+												? `No selectable account succeeded for the requested model.${entitlementDetail} Codex model access is account/workspace gated; default gpt-5.6-sol/terra/luna selectors auto-fallback down the 5.6 tiers to gpt-5.5, and gpt-5.5/gpt-5-codex through the GPT-5.4 family when possible. Set \`unsupportedCodexPolicy: "fallback"\` for the full manual fallback chain, or see \`codex-health\` for per-account details.`
 												: `All ${count} account(s) failed (server errors or auth issues). Check account health with \`codex-health\`.`;
 								runtimeMetrics.failedRequests++;
 								runtimeMetrics.lastError = message;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4744,6 +4744,60 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 		});
 	});
 
+	it("reports actual strict-pool attempts without trying general accounts", async () => {
+		const { AccountManager } = await import("../lib/accounts.js");
+		const configModule = await import("../lib/config.js");
+		const fetchHelpers = await import("../lib/request/fetch-helpers.js");
+
+		// The suite's account-manager mock contains one concrete account. Report a
+		// second configured account so this exercises strict-pool exhaustion while
+		// proving that the general account is never fetched.
+		vi.spyOn(AccountManager.prototype, "getAccountCount").mockReturnValue(2);
+		vi.mocked(configModule.getModelAccountPool).mockReturnValueOnce(["acc-1"]);
+		vi.mocked(configModule.getModelAccountPoolMode).mockReturnValueOnce("strict");
+		vi.mocked(configModule.getUnsupportedCodexPolicy).mockReturnValue("strict");
+		vi.mocked(fetchHelpers.transformRequestForCodex).mockResolvedValueOnce({
+			updatedInit: {
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-5.4-pro" }),
+			},
+			body: { model: "gpt-5.4-pro" },
+		});
+		const errorBody = {
+			error: {
+				code: "model_not_supported_with_chatgpt_account",
+				message:
+					"The 'gpt-5.4-pro' model is not supported when using Codex with a ChatGPT account.",
+			},
+		};
+		vi.mocked(fetchHelpers.handleErrorResponse).mockResolvedValueOnce({
+			response: new Response(JSON.stringify(errorBody), { status: 400 }),
+			rateLimit: undefined,
+			errorBody,
+		});
+		vi.mocked(fetchHelpers.getUnsupportedCodexModelInfo).mockReturnValue({
+			isUnsupported: true,
+			unsupportedModel: "gpt-5.4-pro",
+			message: errorBody.error.message,
+			code: errorBody.error.code,
+		});
+		globalThis.fetch = vi.fn().mockResolvedValueOnce(
+			new Response(JSON.stringify(errorBody), { status: 400 }),
+		);
+
+		const { sdk } = await setupPlugin();
+		const response = await sdk.fetch!("https://api.openai.com/v1/chat", {
+			method: "POST",
+			body: JSON.stringify({ model: "gpt-5.4-pro" }),
+		});
+		const body = await response.text();
+
+		expect(response.status).toBe(503);
+		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+		expect(body).toContain("unsupported on 1 of 1 attempted pooled account(s)");
+		expect(body).not.toContain("All 2 account(s)");
+	});
+
 	it("falls back from gpt-5.3-codex to gpt-5.2-codex when unsupported fallback is enabled", async () => {
 		const configModule = await import("../lib/config.js");
 		const fetchHelpers = await import("../lib/request/fetch-helpers.js");

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -316,6 +316,38 @@ const mockQuotaExhaustionCalls: Array<{
 	model?: string | null;
 }> = [];
 
+type MockManagedAccount = {
+	index: number;
+	accountId?: string;
+	email?: string;
+	refreshToken: string;
+	/** `false` makes rotation skip it, standing in for rate-limited/cooling down. */
+	selectable?: boolean;
+};
+
+/**
+ * Accounts served by the mocked `AccountManager`. Most suites assume the single
+ * default account; tests that need real rotation across several accounts replace
+ * the contents with `setMockManagedAccounts`, and the hooks reset it afterwards.
+ */
+const mockManagedAccounts: MockManagedAccount[] = [];
+
+const setMockManagedAccounts = (
+	accounts: ReadonlyArray<Omit<MockManagedAccount, "index">>,
+) => {
+	mockManagedAccounts.length = 0;
+	accounts.forEach((account, index) =>
+		mockManagedAccounts.push({ ...account, index }),
+	);
+};
+
+const resetMockManagedAccounts = () =>
+	setMockManagedAccounts([
+		{ accountId: "acc-1", email: "user1@example.com", refreshToken: "refresh-1" },
+	]);
+
+resetMockManagedAccounts();
+
 const cloneAccount = (account: (typeof mockStorage.accounts)[number]) => structuredClone(account);
 
 const cloneMockStorage = () => ({
@@ -432,14 +464,11 @@ vi.mock("../lib/storage.js", async () => {
 
 vi.mock("../lib/accounts.js", () => {
 	class MockAccountManager {
-		private accounts = [
-			{
-				index: 0,
-				accountId: "acc-1",
-				email: "user1@example.com",
-				refreshToken: "refresh-1",
-			},
-		];
+		// A getter, not a field: the list is owned by `mockManagedAccounts` so a
+		// test can reshape it after the manager has already been constructed.
+		private get accounts(): MockManagedAccount[] {
+			return mockManagedAccounts;
+		}
 
 		static async loadFromDisk() {
 			return new MockAccountManager();
@@ -449,12 +478,19 @@ vi.mock("../lib/accounts.js", () => {
 			return this.accounts.length;
 		}
 
+		private selectableAccounts(excludedIndices?: ReadonlySet<number>) {
+			return this.accounts.filter(
+				(account) =>
+					account.selectable !== false && !excludedIndices?.has(account.index),
+			);
+		}
+
 		getCurrentOrNextForFamily() {
-			return this.accounts[0] ?? null;
+			return this.selectableAccounts()[0] ?? null;
 		}
 
 		getCurrentOrNextForFamilyHybrid() {
-			return this.accounts[0] ?? null;
+			return this.selectableAccounts()[0] ?? null;
 		}
 
 		getAccountForStrategy(
@@ -464,15 +500,19 @@ vi.mock("../lib/accounts.js", () => {
 			_options?: unknown,
 			preferredAccountIds: readonly string[] = [],
 			poolMode: "preferred" | "strict" = "preferred",
+			excludedIndices?: ReadonlySet<number>,
 		) {
-			const preferred = this.accounts.find(
+			// Honouring `excludedIndices` is what lets a test rotate across several
+			// accounts: without it the caller re-selects account 0 and bails out.
+			const available = this.selectableAccounts(excludedIndices);
+			const preferred = available.find(
 				(account) =>
 					account.accountId !== undefined &&
 					preferredAccountIds.includes(account.accountId),
 			);
 			if (preferred) return preferred;
 			if (poolMode === "strict" && preferredAccountIds.length > 0) return null;
-			return this.getCurrentOrNextForFamilyHybrid();
+			return available[0] ?? null;
 		}
 
 		getSelectionExplainability() {
@@ -3688,6 +3728,7 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		resetMockManagedAccounts();
 		mockStorage.accounts = [
 			{
 				accountId: "acc-1",
@@ -3702,6 +3743,12 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 
 	afterEach(() => {
 		globalThis.fetch = originalFetch;
+		resetMockManagedAccounts();
+		// `clearAllMocks` in beforeEach only clears call records, so a
+		// `mockReturnValue` set by one test would otherwise still be in force for
+		// the next one. `resetAllMocks` puts every module mock back to the
+		// implementation its `vi.mock` factory declared.
+		vi.resetAllMocks();
 		vi.restoreAllMocks();
 	});
 
@@ -4744,19 +4791,37 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 		});
 	});
 
-	it("reports actual strict-pool attempts without trying general accounts", async () => {
-		const { AccountManager } = await import("../lib/accounts.js");
+	/**
+	 * Two *distinct* stored accounts, every upstream call answering
+	 * `model_not_supported_with_chatgpt_account` for gpt-5.4-pro.
+	 *
+	 * The second account is what makes the strict-pool assertions below
+	 * meaningful: with the suite's default single account, "the general account
+	 * was never fetched" holds in `preferred` mode too, so the test could not
+	 * discriminate the mode it exists to cover.
+	 */
+	const setupUnsupportedModelOnEveryAccount = async (
+		accounts: ReadonlyArray<Omit<MockManagedAccount, "index">> = [
+			{ accountId: "acc-1", email: "user1@example.com", refreshToken: "refresh-1" },
+			{ accountId: "acc-2", email: "user2@example.com", refreshToken: "refresh-2" },
+		],
+	) => {
+		const accountsModule = await import("../lib/accounts.js");
 		const configModule = await import("../lib/config.js");
 		const fetchHelpers = await import("../lib/request/fetch-helpers.js");
-
-		// The suite's account-manager mock contains one concrete account. Report a
-		// second configured account so this exercises strict-pool exhaustion while
-		// proving that the general account is never fetched.
-		vi.spyOn(AccountManager.prototype, "getAccountCount").mockReturnValue(2);
-		vi.mocked(configModule.getModelAccountPool).mockReturnValueOnce(["acc-1"]);
-		vi.mocked(configModule.getModelAccountPoolMode).mockReturnValueOnce("strict");
+		// Strict policy: no model fallback, so the traversal exhausts accounts and
+		// reaches the terminal diagnostics under test.
 		vi.mocked(configModule.getUnsupportedCodexPolicy).mockReturnValue("strict");
-		vi.mocked(fetchHelpers.transformRequestForCodex).mockResolvedValueOnce({
+		vi.mocked(configModule.getFallbackOnUnsupportedCodexModel).mockReturnValue(false);
+		// The suite-wide mock answers every account with the same token id, which
+		// would rewrite each account's id to that one value and make the pool keys
+		// stop matching. Keep the stored id, which is what the real resolver does
+		// for a stable, non-org account id.
+		vi.mocked(accountsModule.resolveRequestAccountId).mockImplementation(
+			(storedId, _source, tokenId) => storedId ?? tokenId,
+		);
+		setMockManagedAccounts(accounts);
+		vi.mocked(fetchHelpers.transformRequestForCodex).mockResolvedValue({
 			updatedInit: {
 				method: "POST",
 				body: JSON.stringify({ model: "gpt-5.4-pro" }),
@@ -4770,7 +4835,7 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 					"The 'gpt-5.4-pro' model is not supported when using Codex with a ChatGPT account.",
 			},
 		};
-		vi.mocked(fetchHelpers.handleErrorResponse).mockResolvedValueOnce({
+		vi.mocked(fetchHelpers.handleErrorResponse).mockResolvedValue({
 			response: new Response(JSON.stringify(errorBody), { status: 400 }),
 			rateLimit: undefined,
 			errorBody,
@@ -4781,21 +4846,144 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 			message: errorBody.error.message,
 			code: errorBody.error.code,
 		});
-		globalThis.fetch = vi.fn().mockResolvedValueOnce(
-			new Response(JSON.stringify(errorBody), { status: 400 }),
-		);
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(new Response(JSON.stringify(errorBody), { status: 400 }));
+	};
 
-		const { sdk } = await setupPlugin();
-		const response = await sdk.fetch!("https://api.openai.com/v1/chat", {
+	const requestGpt54Pro = (sdk: { fetch?: PluginType["fetch"] }) =>
+		sdk.fetch!("https://api.openai.com/v1/chat", {
 			method: "POST",
 			body: JSON.stringify({ model: "gpt-5.4-pro" }),
 		});
+
+	it("reports actual strict-pool attempts without trying general accounts", async () => {
+		const configModule = await import("../lib/config.js");
+		await setupUnsupportedModelOnEveryAccount();
+		vi.mocked(configModule.getModelAccountPool).mockReturnValue(["acc-1"]);
+		vi.mocked(configModule.getModelAccountPoolMode).mockReturnValue("strict");
+
+		const { sdk } = await setupPlugin();
+		const response = await requestGpt54Pro(sdk);
+		const body = await response.text();
+
+		expect(response.status).toBe(503);
+		// acc-2 is a real, healthy, non-pooled account: strict mode must not reach it.
+		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+		expect(body).toContain("strict_pool_unavailable");
+		// Pool size is counted over resolved accounts, not over configured keys.
+		expect(body).toContain("1 configured pool key(s) resolved to 1 account(s)");
+		expect(body).toContain("unsupported on 1 of 1 attempted pooled account(s)");
+		expect(body).not.toContain("All 2 account(s)");
+	});
+
+	it("spills onto the general account when the same pool is preferred, not strict", async () => {
+		const configModule = await import("../lib/config.js");
+		await setupUnsupportedModelOnEveryAccount();
+		vi.mocked(configModule.getModelAccountPool).mockReturnValue(["acc-1"]);
+		vi.mocked(configModule.getModelAccountPoolMode).mockReturnValue("preferred");
+
+		const { sdk } = await setupPlugin();
+		const response = await requestGpt54Pro(sdk);
+		const body = await response.text();
+
+		// The pool mode is the only difference from the strict test above: here the
+		// traversal reaches acc-2 and the upstream rejection is what surfaces.
+		expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+		expect(response.status).toBe(400);
+		expect(body).not.toContain("strict_pool_unavailable");
+	});
+
+	it("names an unresolved strict-pool key instead of counting it as an account", async () => {
+		const configModule = await import("../lib/config.js");
+		await setupUnsupportedModelOnEveryAccount();
+		vi.mocked(configModule.getModelAccountPool).mockReturnValue([
+			"acc-1",
+			"typo-account-id",
+		]);
+		vi.mocked(configModule.getModelAccountPoolMode).mockReturnValue("strict");
+
+		const { sdk } = await setupPlugin();
+		const response = await requestGpt54Pro(sdk);
 		const body = await response.text();
 
 		expect(response.status).toBe(503);
 		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-		expect(body).toContain("unsupported on 1 of 1 attempted pooled account(s)");
-		expect(body).not.toContain("All 2 account(s)");
+		expect(body).toContain("2 configured pool key(s) resolved to 1 account(s)");
+		expect(body).toContain("1 configured pool key(s) matched no known account");
+		// The unresolved key is not an account, so it must not inflate this count.
+		expect(body).not.toContain("pooled account(s) were never attempted");
+	});
+
+	it("reports how many general accounts the backend rejected the model on", async () => {
+		// acc-2 is configured but not selectable (rate-limited or cooling down), so
+		// the traversal ends with one account attempted out of two configured.
+		await setupUnsupportedModelOnEveryAccount([
+			{ accountId: "acc-1", email: "user1@example.com", refreshToken: "refresh-1" },
+			{
+				accountId: "acc-2",
+				email: "user2@example.com",
+				refreshToken: "refresh-2",
+				selectable: false,
+			},
+		]);
+
+		const { sdk } = await setupPlugin();
+		const response = await requestGpt54Pro(sdk);
+		const body = await response.text();
+
+		expect(response.status).toBe(503);
+		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+		expect(body).toContain(
+			"No selectable account succeeded for the requested model across 2 configured account(s)",
+		);
+		expect(body).toContain(
+			"rejected 'gpt-5.4-pro' as not entitled for Codex OAuth on 1 of 1 attempted account(s)",
+		);
+		expect(body).toContain("1 configured account(s) were unavailable or excluded");
+	});
+
+	it("does not reuse the previous request's entitlement failure when nothing was attempted", async () => {
+		await setupUnsupportedModelOnEveryAccount([
+			{ accountId: "acc-1", email: "user1@example.com", refreshToken: "refresh-1" },
+			{
+				accountId: "acc-2",
+				email: "user2@example.com",
+				refreshToken: "refresh-2",
+				selectable: false,
+			},
+		]);
+
+		const { sdk } = await setupPlugin();
+		// The first request ends in entitlement exhaustion, leaving
+		// runtimeMetrics.lastErrorCategory = "unsupported-model". runtimeMetrics is
+		// plugin-scoped, so that value survives into the next request.
+		await requestGpt54Pro(sdk);
+
+		// The second request never reaches an account at all, so it must not inherit
+		// the previous request's entitlement verdict — nor render it as "0 of 0".
+		setMockManagedAccounts([
+			{
+				accountId: "acc-1",
+				email: "user1@example.com",
+				refreshToken: "refresh-1",
+				selectable: false,
+			},
+			{
+				accountId: "acc-2",
+				email: "user2@example.com",
+				refreshToken: "refresh-2",
+				selectable: false,
+			},
+		]);
+		const response = await requestGpt54Pro(sdk);
+		const body = await response.text();
+
+		expect(response.status).toBe(503);
+		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+		expect(body).not.toContain("0 of 0");
+		expect(body).not.toContain("not entitled for Codex OAuth");
+		expect(body).toContain("All 2 account(s) failed");
 	});
 
 	it("falls back from gpt-5.3-codex to gpt-5.2-codex when unsupported fallback is enabled", async () => {

--- a/test/rotation-strategy.test.ts
+++ b/test/rotation-strategy.test.ts
@@ -334,6 +334,41 @@ describe("strategy dispatcher (#183)", () => {
 		},
 	);
 
+	it("sticky stays on its current strict-pool account, then advances only within the pool", () => {
+		const pool = ["account-id-2", "account-id-3"];
+		const first = manager.getAccountForStrategy(
+			"sticky",
+			FAMILY,
+			"gpt-5.6-sol",
+			undefined,
+			pool,
+			"strict",
+		);
+		expect(first?.accountId).toBe("account-id-2");
+		expect(
+			manager.getAccountForStrategy(
+				"sticky",
+				FAMILY,
+				"gpt-5.6-sol",
+				undefined,
+				pool,
+				"strict",
+			),
+		).toBe(first);
+
+		const next = manager.getAccountForStrategy(
+			"sticky",
+			FAMILY,
+			"gpt-5.6-sol",
+			undefined,
+			pool,
+			"strict",
+			new Set([first!.index]),
+		);
+		expect(next?.accountId).toBe("account-id-3");
+		expect([first?.accountId, next?.accountId]).not.toContain("account-id-1");
+	});
+
 	it("falls back to the general pool when configured IDs are unknown", () => {
 		const selected = manager.getAccountForStrategy(
 			"sticky",


### PR DESCRIPTION
## Summary\n- keep sticky routing within strict model account pools\n- report actual attempted, unsupported, and unavailable accounts in routing errors\n- add strict-pool sticky routing regression coverage\n\n## Verification\n- npm test\n- npm run typecheck\n- npm run lint\n\nNote: this branch is based on the fork's current main, which is ahead of upstream main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account-routing diagnostics by reliably tracking accounts across retries, removals, and traversal changes.
  * Corrected entitlement and service-unavailable messages to accurately reflect accounts evaluated during the current request.
  * Strict account pools now distinguish resolved, unresolved, attempted, and unavailable accounts without checking accounts outside the configured pool.
  * Sticky routing remains on the current eligible account and advances to the next available account when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

the pr keeps sticky routing within strict model pools and expands terminal routing diagnostics.
- adds stable attempted and unsupported account tracking
- distinguishes resolved accounts, unresolved keys, and unavailable accounts
- adds vitest coverage for strict versus preferred routing, but not the legacy multi-seat identity case

<h3>Confidence Score: 4/5</h3>

the pr should not merge until strict-pool diagnostics count unresolved business seats consistently.

legacy workspace pools can contain multiple live business seats whose unresolved member identities collapse to one attempted key, causing the terminal error to report an attempted account as unavailable.

**Files Needing Attention:** index.ts and test/index.test.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| index.ts | strict-pool routing remains contained, but diagnostics still mix per-account and deduplicated identity cardinalities for unresolved business seats. |
| test/index.test.ts | adds useful strict-pool diagnostic coverage, but misses multiple business seats sharing one legacy workspace key. |
| test/rotation-strategy.test.ts | verifies sticky selection remains within a strict pool and advances only to another pooled account. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[legacy workspace pool key] --> B[multiple matching business seats]
  B --> C[fetch each selectable seat]
  C --> D[deduplicate attempted pool identities]
  B --> E[count every resolved live account]
  D --> F[subtract attempted count]
  E --> F
  F --> G[reported unavailable accounts]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
index.ts:304
**attempted seat identities collapse**

if a legacy workspace pool contains multiple business seats without resolved account-user ids, `getModelPoolAccountKey` gives those seats the same workspace key. `fetchedAccountKeys` then counts multiple attempted seats once while `poolAccountCount` counts each seat, causing the strict-pool error to report an attempted seat as unavailable.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(routing): make the pool-exhaustion d..."](https://github.com/ndycode/oc-codex-multi-auth/commit/783c3612afc5e3b403a993e77f3d0ae0e1445198) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56233292)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Account rotation and selection](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/account-rotation-and-selection.md)

<!-- /greptile_comment -->