### PR TITLE
fix(rotation): resolve pool keys by identity when computing pool wait time

### DIFF
--- a/lib/accounts/rotation.ts
+++ b/lib/accounts/rotation.ts
@@ -482,12 +482,19 @@ export class AccountRotation {
 		accountIds?: readonly string[],
 	): number {
 		const now = nowMs();
-		const accountIdSet = accountIds?.length ? new Set(accountIds) : null;
+		// Pool membership is resolved exactly as selection resolves it, via
+		// `matchesModelPoolAccountKey` (see `getPreferredSelectableIndices`).
+		// Raw `accountId` equality would silently match nothing for a
+		// member-scoped `seat:[...]` key -- the format `codex-pool add` writes for
+		// every account with a resolvable member id -- and an empty pool falls
+		// through to `return 0` below, so a fully rate-limited pool reported "no
+		// wait" and its caller answered 503 instead of a 429 with a retry hint.
+		const pooledKeys = accountIds?.length ? accountIds : null;
 		const enabledAccounts = this.state.accounts.filter(
 			(account) =>
 				account.enabled !== false &&
-				(accountIdSet === null ||
-					(account.accountId !== undefined && accountIdSet.has(account.accountId))),
+				(pooledKeys === null ||
+					pooledKeys.some((key) => matchesModelPoolAccountKey(account, key))),
 		);
 		const available = enabledAccounts.filter((account) =>
 			this.isSelectable(account, family, model),

--- a/test/accounts.test.ts
+++ b/test/accounts.test.ts
@@ -10,6 +10,7 @@ import {
   shouldUpdateAccountIdFromToken,
   getAccountIdCandidates,
 } from "../lib/accounts.js";
+import { getModelPoolAccountKey } from "../lib/accounts/pool-identity.js";
 import { getHealthTracker, getTokenTracker, resetTrackers } from "../lib/rotation.js";
 import type { OAuthAuthDetails } from "../lib/types.js";
 import { SCOPE } from "../lib/auth/auth.js";
@@ -1453,6 +1454,77 @@ describe("AccountManager", () => {
       const waitTime = manager.getMinWaitTimeForFamily("codex", "gpt-5.2");
       expect(waitTime).toBeGreaterThan(0);
       expect(waitTime).toBeLessThanOrEqual(45000);
+    });
+
+    /**
+     * The pool-filtered overload has to resolve pool keys the same way routing
+     * does (`matchesModelPoolAccountKey`). A member-scoped seat key is what
+     * `codex-pool add` writes for any account with a resolvable member id, and
+     * it never equals `account.accountId`.
+     */
+    describe("with a configured account pool", () => {
+      const now = Date.now();
+      const pooledStorage = () => ({
+        version: 3 as const,
+        activeIndex: 0,
+        accounts: [
+          {
+            refreshToken: "token-1",
+            accountId: "acct-workspace",
+            accountUserId: "member-1",
+            addedAt: now,
+            lastUsed: now,
+            rateLimitResetTimes: { codex: now + 30000 },
+          },
+          {
+            refreshToken: "token-2",
+            accountId: "acct-workspace",
+            accountUserId: "member-2",
+            addedAt: now,
+            lastUsed: now,
+            rateLimitResetTimes: { codex: now + 60000 },
+          },
+        ],
+      });
+
+      it("reports the wait for a legacy workspace-wide pool key", () => {
+        const manager = new AccountManager(undefined, pooledStorage());
+        const waitTime = manager.getMinWaitTimeForFamily("codex", null, [
+          "acct-workspace",
+        ]);
+        expect(waitTime).toBeGreaterThan(0);
+        expect(waitTime).toBeLessThanOrEqual(30000);
+      });
+
+      it("reports the wait for a member-scoped seat pool key", () => {
+        const manager = new AccountManager(undefined, pooledStorage());
+        const seatKey = getModelPoolAccountKey({
+          accountId: "acct-workspace",
+          accountUserId: "member-2",
+        });
+        expect(seatKey).toBe('seat:["acct-workspace","member-2"]');
+
+        const waitTime = manager.getMinWaitTimeForFamily("codex", null, [
+          seatKey as string,
+        ]);
+        // Only member-2 is pooled, so the answer is its own reset, not member-1's.
+        expect(waitTime).toBeGreaterThan(30000);
+        expect(waitTime).toBeLessThanOrEqual(60000);
+      });
+
+      it("returns 0 when a pooled account is still selectable", () => {
+        const storage = pooledStorage();
+        delete (storage.accounts[1] as { rateLimitResetTimes?: unknown })
+          .rateLimitResetTimes;
+        const manager = new AccountManager(undefined, storage);
+        const seatKey = getModelPoolAccountKey({
+          accountId: "acct-workspace",
+          accountUserId: "member-2",
+        });
+        expect(
+          manager.getMinWaitTimeForFamily("codex", null, [seatKey as string]),
+        ).toBe(0);
+      });
     });
   });
 


### PR DESCRIPTION
## The bug

`AccountRotation.getMinWaitTimeForFamily` filtered its pool members with raw string equality:

```ts
account.accountId !== undefined && accountIdSet.has(account.accountId)
```

A member-scoped `seat:["<accountId>","<accountUserId>"]` key — the format `codex-pool add` writes for **every** account with a resolvable member id — never equals `account.accountId`. So the filter matched nothing, `enabledAccounts.length === 0` short-circuited to `return 0`, and a fully rate-limited strict pool reported *no wait at all*.

The caller in `index.ts` turns that into:

```ts
status: poolWaitMs > 0 ? 429 : 503
waitDetail = poolWaitMs > 0 ? ` Try again in ${formatWaitTime(poolWaitMs)}.` : " Check the pooled accounts with `codex-health`."
```

so the user got a **503 "Check the pooled accounts with `codex-health`"** instead of a **429 "Try again in 4m"** — losing both the retry-after signal and the correct status class for client backoff.

## Root cause

Not a fresh mistake — an incomplete fix:

- `dcc1e59` (#222, strict pool routing) added the pool filter here using raw `accountId` equality.
- `890437d` (#231, Business seat identity) converted the **selection** path in the same file, `getPreferredSelectableIndices`, to `matchesModelPoolAccountKey` — and left this identical pattern untouched.

The two functions in `lib/accounts/rotation.ts` have disagreed on what pool membership means ever since. Legacy workspace-wide keys kept working, which is why it went unnoticed.

## The fix

Resolve pool membership the same way selection does, via `matchesModelPoolAccountKey`.

## Tests

Three cases in `test/accounts.test.ts` under `getMinWaitTimeForFamily > with a configured account pool`:

- legacy workspace-wide key → wait reported (passed before, regression guard)
- **member-scoped seat key → wait reported (failed before: `expected 0 to be greater than 30000`)**
- a still-selectable pooled account → `0`

The seat-key test also pins that only the named member's reset is considered, not its workspace sibling's.

## Verification

`npm run build` + `tsc --noEmit` clean, `eslint . --ext .ts` clean, full suite **3052 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012avqAhpaF3XzEGwYwBAjEK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rate-limit handling for member-scoped account pools.
  * Fully rate-limited pools now return a 429 response with an accurate retry wait time instead of an incorrect 503 response.
  * Improved pool matching so legacy and member-specific pool configurations resolve correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr aligns strict-pool wait calculation with selection by resolving workspace and business-seat identity through the shared pool-key matcher.

- adds vitest coverage for legacy workspace keys, member-scoped seat keys, sibling isolation, and selectable pooled accounts.
- no concurrency, token-safety, or windows-filesystem behavior changes are introduced.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge, with the corrected pool identity behavior covered by focused tests.

selection and wait-time calculation now resolve identical pool keys through the same matcher, and the tests cover both legacy workspace-wide and member-scoped behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/accounts/rotation.ts | uses the same stable identity matcher for strict-pool wait calculation and account selection, preserving legacy workspace-key compatibility. |
| test/accounts.test.ts | adds focused vitest regression coverage for workspace and seat pool identities without exposing tokens. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[configured pool keys] --> B[matchesModelPoolAccountKey]
  B --> C[enabled pooled accounts]
  C --> D{any account selectable?}
  D -->|yes| E[return zero wait]
  D -->|no| F[return shortest pooled-account wait]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rotation): resolve pool keys by iden..."](https://github.com/ndycode/oc-codex-multi-auth/commit/2b8de079afd11a11020752fa539bad0a5d6bae64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56637724)</sub>

**Context used:**

- Knowledge Base — [Account rotation and selection](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/account-rotation-and-selection.md)

<!-- /greptile_comment -->