### PR TITLE
fix(routing): ignore quota headers on entitlement errors

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -794,12 +794,27 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 		 * Take an account out of rotation whenever the backend reports one of its
 		 * quota windows as fully spent (issue #218).
 		 *
-		 * Every Codex response — success or 429 — carries `x-codex-*-used-percent`
-		 * and the matching reset time, so the moment an account hits 0% left we
-		 * can record it instead of rediscovering it with a failed request on every
-		 * subsequent prompt. The block lands on the persisted `rateLimitResetTimes`
-		 * map, so it is remembered across restarts and shared with other processes,
-		 * and it clears itself once the window rolls over.
+		 * Codex carries `x-codex-*-used-percent` and the matching reset time on a
+		 * served request and on a refused one alike, so the moment an account hits
+		 * 0% left we can record it instead of rediscovering it with a failed request
+		 * on every subsequent prompt. The block lands on the persisted
+		 * `rateLimitResetTimes` map, so it is remembered across restarts and shared
+		 * with other processes, and it clears itself once the window rolls over.
+		 *
+		 * Call this only for responses whose headers are authoritative: one the
+		 * backend served, or one it refused for a confirmed usage limit. Every other
+		 * error class — entitlement (issues #16/#17), auth, 5xx, or an upstream
+		 * overload dressed up as a 429 — can echo a stale quota snapshot next to an
+		 * unrelated failure, and writing that echo locked healthy accounts out for
+		 * hours. `handleErrorResponse` makes that call once and reports it back as
+		 * `quotaHeadersAuthoritative`.
+		 *
+		 * The resulting gap is deliberate: an account that really is spent but gets
+		 * a 5xx stays selectable until its next genuine 429, which costs one wasted
+		 * request — cheaper than a false multi-hour block on a healthy account.
+		 *
+		 * @returns true when the headers report a spent window, whether or not the
+		 *   stored block moved. Callers use it to stop retrying this account.
 		 */
 		const applyQuotaExhaustion = (
 			manager: AccountManager,
@@ -807,20 +822,22 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 			account: ManagedAccount,
 			family: ModelFamily,
 			model: string | null | undefined,
-		): void => {
+		): boolean => {
 			try {
 				const resetAtMs = getQuotaExhaustedResetAtMs(headers);
-				if (resetAtMs === undefined) return;
-				if (!manager.markQuotaExhausted(account, resetAtMs, family, model)) return;
+				if (resetAtMs === undefined) return false;
+				if (!manager.markQuotaExhausted(account, resetAtMs, family, model)) return true;
 				account.lastSwitchReason = "rate-limit";
 				manager.saveToDiskDebounced();
 				logWarn(
 					`Account ${account.index + 1} (${account.email ?? "unknown"}) has no ${family} quota left; skipping it for ${formatWaitTime(resetAtMs - Date.now())}.`,
 				);
+				return true;
 			} catch (error) {
 				logDebug(
 					`[${PLUGIN_NAME}] Failed to apply quota exhaustion: ${error instanceof Error ? error.message : String(error)}`,
 				);
+				return false;
 			}
 		};
 
@@ -2677,37 +2694,41 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 								latencyMs: fetchLatencyMs,
 								headers: Object.fromEntries(response.headers.entries()),
 							});
-							void recordPromptQuotaHeaders(response, account, accountCount);
-							if (response.ok) {
-								applyQuotaExhaustion(
+							// The TUI snapshot and the durable rotation block read the same
+							// `x-codex-*` headers, so they share one authority decision — gating
+							// only the block would leave the status line reporting "0% left" for
+							// an account the router considers healthy.
+							const recordQuotaHeaders = (): boolean => {
+								void recordPromptQuotaHeaders(response, account, accountCount);
+								return applyQuotaExhaustion(
 									accountManager,
 									response.headers,
 									account,
 									modelFamily,
 									model,
 								);
-							}
+							};
 
-								if (!response.ok) {
+							if (response.ok) {
+								recordQuotaHeaders();
+							} else {
 									const contextOverflowResult = await handleContextOverflow(response, model);
 									if (contextOverflowResult.handled) {
 										return contextOverflowResult.response;
 									}
 
-					const { response: errorResponse, rateLimit, errorBody, retryAsServerError } =
-						await handleErrorResponse(response, {
-							requestCorrelationId,
-							threadId: threadIdCandidate,
-						});
-					if (rateLimit) {
-						applyQuotaExhaustion(
-							accountManager,
-							response.headers,
-							account,
-							modelFamily,
-							model,
-						);
-					}
+					const {
+						response: errorResponse,
+						rateLimit,
+						errorBody,
+						retryAsServerError,
+						quotaHeadersAuthoritative,
+					} = await handleErrorResponse(response, {
+						requestCorrelationId,
+						threadId: threadIdCandidate,
+					});
+					const quotaExhausted =
+						quotaHeadersAuthoritative === true && recordQuotaHeaders();
 
 			const workspaceDeactivated = isDeactivatedWorkspaceError(errorBody, response.status);
 				if (workspaceDeactivated) {
@@ -3026,7 +3047,12 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 																														);
 																														const waitLabel = formatWaitTime(delayMs);
 
+																														// A spent window will still be spent in a second, and the block
+																														// just written for it is monotonic — a short retry that happened
+																														// to succeed could not walk it back, so the account would serve
+																														// traffic while rotation still considers it blocked. Rotate.
 																														if (
+																															!quotaExhausted &&
 																															delayMs <= RATE_LIMIT_SHORT_RETRY_THRESHOLD_MS &&
 																															consumeRetryBudget(
 																																"rateLimitShort",

--- a/index.ts
+++ b/index.ts
@@ -2678,13 +2678,15 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 								headers: Object.fromEntries(response.headers.entries()),
 							});
 							void recordPromptQuotaHeaders(response, account, accountCount);
-							applyQuotaExhaustion(
-								accountManager,
-								response.headers,
-								account,
-								modelFamily,
-								model,
-							);
+							if (response.ok) {
+								applyQuotaExhaustion(
+									accountManager,
+									response.headers,
+									account,
+									modelFamily,
+									model,
+								);
+							}
 
 								if (!response.ok) {
 									const contextOverflowResult = await handleContextOverflow(response, model);
@@ -2697,6 +2699,15 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 							requestCorrelationId,
 							threadId: threadIdCandidate,
 						});
+					if (rateLimit) {
+						applyQuotaExhaustion(
+							accountManager,
+							response.headers,
+							account,
+							modelFamily,
+							model,
+						);
+					}
 
 			const workspaceDeactivated = isDeactivatedWorkspaceError(errorBody, response.status);
 				if (workspaceDeactivated) {

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -437,6 +437,11 @@ export interface ErrorHandlingResult {
         rateLimit?: RateLimitInfo;
         errorBody?: unknown;
         retryAsServerError?: boolean;
+        /**
+         * Whether this response's `x-codex-*` quota headers describe the account's
+         * real quota state. See {@link isQuotaHeaderAuthority}.
+         */
+        quotaHeadersAuthoritative?: boolean;
 }
 
 export interface ErrorHandlingOptions {
@@ -927,7 +932,6 @@ export async function handleErrorResponse(
         }
         
         const finalResponse = mapped ?? response;
-        const rateLimit = extractRateLimitInfoFromBody(finalResponse, bodyText);
 
         let errorBody: unknown;
         try {
@@ -946,6 +950,18 @@ export async function handleErrorResponse(
         );
         const errorResponse = ensureJsonErrorResponse(finalResponse, normalizedError);
         const retryAsServerError = isServerOverloadedError(normalizedError);
+        // Decide once, from the same overload verdict the caller branches on, so
+        // the durable block and the retry-after delay can never disagree about
+        // whether these headers mean anything.
+        const quotaHeadersAuthoritative = isQuotaHeaderAuthority(
+                finalResponse.status,
+                retryAsServerError,
+        );
+        const rateLimit = extractRateLimitInfoFromBody(
+                finalResponse,
+                bodyText,
+                quotaHeadersAuthoritative,
+        );
 
         if (finalResponse.status === HTTP_STATUS.UNAUTHORIZED) {
                 logWarn("Codex upstream returned 401 Unauthorized", diagnostics);
@@ -962,6 +978,7 @@ export async function handleErrorResponse(
 		rateLimit,
 		errorBody: normalizedError,
 		retryAsServerError,
+		quotaHeadersAuthoritative: quotaHeadersAuthoritative && rateLimit !== undefined,
 	};
 }
 
@@ -1039,9 +1056,31 @@ function mapUsageLimit404WithBody(response: Response, bodyText: string): Respons
         });
 }
 
+/**
+ * Whether the `x-codex-*` quota headers on an error response may be trusted as
+ * the account's real quota state.
+ *
+ * They are believable only when the backend weighed this very request against
+ * the quota and refused it for a usage limit — HTTP 429, including a 404 that
+ * `mapUsageLimit404WithBody` remapped. Every other error class can echo a stale
+ * snapshot alongside an unrelated failure: entitlement errors (issues #16/#17),
+ * auth failures, 5xx, and upstream overloads dressed up as a 429. Acting on
+ * that echo is what blocked healthy accounts for hours.
+ *
+ * Every consumer of those headers routes through this predicate, so the rule
+ * lives in exactly one place instead of being re-derived per call site.
+ */
+function isQuotaHeaderAuthority(
+        status: number,
+        isServerOverload: boolean,
+): boolean {
+        return status === HTTP_STATUS.TOO_MANY_REQUESTS && !isServerOverload;
+}
+
 function extractRateLimitInfoFromBody(
         response: Response,
         bodyText: string,
+        quotaHeadersAuthoritative: boolean,
 ): RateLimitInfo | undefined {
         const isStatusRateLimit =
                 response.status === HTTP_STATUS.TOO_MANY_REQUESTS;
@@ -1068,8 +1107,13 @@ function extractRateLimitInfoFromBody(
                 );
         if (!isRateLimit) return undefined;
 
+        // The uncapped exhausted-window reset rides on the same authority rule as
+        // the durable block: on any status other than a genuine 429 a stale
+        // `used-percent: 100` would otherwise become an hours-long, uncappable
+        // `retryAfterMs` and freeze the account through `markRateLimitedWithReason`
+        // — the exact block the caller-side gate was added to prevent.
         const retryAfterMs =
-                parseRetryAfterMs(response, parsed) ?? 60000;
+                parseRetryAfterMs(response, parsed, quotaHeadersAuthoritative) ?? 60000;
 
         return { retryAfterMs, code: parsed?.code };
 }
@@ -1266,17 +1310,21 @@ function ensureJsonErrorResponse(response: Response, payload: ErrorPayload): Res
 
 function parseRetryAfterMs(
         response: Response,
-        parsedBody?: { resetsAt?: number; retryAfterMs?: number },
+        parsedBody: { resetsAt?: number; retryAfterMs?: number } | undefined,
+        trustExhaustedWindows: boolean,
 ): number | null {
         // A window the backend reports as fully spent (`used-percent >= 100`)
         // outranks every other signal, and is deliberately uncapped. Its reset
         // is the earliest moment the account can serve again; a `retry-after`
         // of 30s or the sooner 5h reset would just put the account back into
-        // rotation to fail again (issue #218).
-        const exhaustedResetAtMs = getQuotaExhaustedResetAtMs(response.headers);
-        if (exhaustedResetAtMs !== undefined) {
-                const delta = exhaustedResetAtMs - Date.now();
-                if (delta > 0) return delta;
+        // rotation to fail again (issue #218). Only honour it when the caller
+        // says those headers are authoritative for this response.
+        if (trustExhaustedWindows) {
+                const exhaustedResetAtMs = getQuotaExhaustedResetAtMs(response.headers);
+                if (exhaustedResetAtMs !== undefined) {
+                        const delta = exhaustedResetAtMs - Date.now();
+                        if (delta > 0) return delta;
+                }
         }
 
         if (parsedBody?.retryAfterMs !== undefined) {
@@ -1320,12 +1368,20 @@ function parseRetryAfterMs(
         // or an ISO `-reset-at` produces a candidate instead of falling back to
         // the 60s default. Windows the plan has switched off are skipped: their
         // reset says nothing about when this request can go through.
-        for (const window of parseCodexQuotaWindows(response.headers, now)) {
-                if (isQuotaWindowDisabled(window)) continue;
-                const resetAtMs = window.resetAtMs;
-                if (typeof resetAtMs !== "number" || !Number.isFinite(resetAtMs)) continue;
-                const delta = resetAtMs - now;
-                if (delta > 0) resetCandidates.push(delta);
+        //
+        // This is the second uncapped read of the same `x-codex-*` headers, so it
+        // takes the same authority gate as the exhausted-window shortcut above:
+        // otherwise an untrusted snapshot walks straight back in through the
+        // "ordinary throttle" door and produces the very hours-long delay the
+        // shortcut was gated to prevent.
+        if (trustExhaustedWindows) {
+                for (const window of parseCodexQuotaWindows(response.headers, now)) {
+                        if (isQuotaWindowDisabled(window)) continue;
+                        const resetAtMs = window.resetAtMs;
+                        if (typeof resetAtMs !== "number" || !Number.isFinite(resetAtMs)) continue;
+                        const delta = resetAtMs - now;
+                        if (delta > 0) resetCandidates.push(delta);
+                }
         }
 
         const resetAtHeaders = ["x-ratelimit-reset"];

--- a/test/fetch-helpers.test.ts
+++ b/test/fetch-helpers.test.ts
@@ -1931,3 +1931,117 @@ describe("createAbortError (issue #176)", () => {
 		expect(createAbortError(undefined).message).toBe("Aborted");
 	});
 });
+
+describe("quota header authority (issues #16/#17 vs #218)", () => {
+	const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
+
+	/**
+	 * The stale snapshot an unrelated failure can echo: a window the backend
+	 * last saw as fully spent, resetting five hours out.
+	 */
+	const staleExhaustedHeaders = () => ({
+		"x-codex-primary-used-percent": "100",
+		"x-codex-primary-window-minutes": "300",
+		"x-codex-primary-reset-at": String(
+			Math.floor((Date.now() + FIVE_HOURS_MS) / 1000),
+		),
+	});
+
+	it("trusts the headers on a confirmed usage-limit 429", async () => {
+		const response = new Response(
+			JSON.stringify({ error: { code: "usage_limit_reached" } }),
+			{ status: 429, headers: staleExhaustedHeaders() },
+		);
+
+		const { rateLimit, quotaHeadersAuthoritative } =
+			await handleErrorResponse(response);
+
+		expect(quotaHeadersAuthoritative).toBe(true);
+		// The spent window outranks the 60s fallback and stays uncapped.
+		expect(rateLimit?.retryAfterMs).toBeGreaterThan(FIVE_HOURS_MS - 60_000);
+	});
+
+	it("trusts the headers on a usage-limit 404 remapped to 429", async () => {
+		const response = new Response(
+			JSON.stringify({ error: { code: "usage_limit_reached" } }),
+			{ status: 404, headers: staleExhaustedHeaders() },
+		);
+
+		const { response: result, quotaHeadersAuthoritative } =
+			await handleErrorResponse(response);
+
+		expect(result.status).toBe(429);
+		expect(quotaHeadersAuthoritative).toBe(true);
+	});
+
+	it("ignores the headers on an entitlement error", async () => {
+		const response = new Response(
+			JSON.stringify({
+				error: {
+					code: "usage_not_included",
+					message: "Usage not included in your plan.",
+				},
+			}),
+			{ status: 400, headers: staleExhaustedHeaders() },
+		);
+
+		const { rateLimit, quotaHeadersAuthoritative } =
+			await handleErrorResponse(response);
+
+		expect(rateLimit).toBeUndefined();
+		expect(quotaHeadersAuthoritative).toBeFalsy();
+	});
+
+	it("ignores the headers on a non-429 error whose text merely mentions a usage limit", async () => {
+		// The body-text match is deliberately loose, so it alone is not proof the
+		// backend refused this request for quota. Before the authority rule this
+		// path wrote an uncapped 5h block onto a healthy account.
+		const response = new Response(
+			JSON.stringify({
+				error: {
+					message: "You've reached your usage limit for gpt-5.6-sol on your plan.",
+				},
+			}),
+			{ status: 400, headers: staleExhaustedHeaders() },
+		);
+
+		const { rateLimit, quotaHeadersAuthoritative } =
+			await handleErrorResponse(response);
+
+		expect(quotaHeadersAuthoritative).toBeFalsy();
+		expect(rateLimit?.retryAfterMs).toBe(60000);
+	});
+
+	it("ignores the headers on a 429-shaped upstream overload", async () => {
+		const response = new Response(
+			JSON.stringify({
+				error: {
+					type: "service_unavailable_error",
+					code: "server_is_overloaded",
+					message: "Our servers are currently overloaded. Please try again later.",
+					retry_after_ms: 1750,
+				},
+			}),
+			{ status: 429, headers: staleExhaustedHeaders() },
+		);
+
+		const { rateLimit, retryAsServerError, quotaHeadersAuthoritative } =
+			await handleErrorResponse(response);
+
+		expect(retryAsServerError).toBe(true);
+		expect(quotaHeadersAuthoritative).toBe(false);
+		// A ten-second blip must not park the account until the quota reset.
+		expect(rateLimit?.retryAfterMs).toBe(1750);
+	});
+
+	it("ignores the headers on a 5xx", async () => {
+		const response = new Response(
+			JSON.stringify({ error: { message: "internal error" } }),
+			{ status: 503, headers: staleExhaustedHeaders() },
+		);
+
+		const { quotaHeadersAuthoritative } = await handleErrorResponse(response);
+
+		expect(quotaHeadersAuthoritative).toBeFalsy();
+	});
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4102,6 +4102,42 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 			expect((await sendPrompt()).status).toBe(200);
 			expect(mockQuotaExhaustionCalls).toEqual([]);
 		});
+
+		it("does not persist exhausted headers from a non-rate-limit error", async () => {
+			respondWith(
+				{
+					"x-codex-primary-used-percent": "100",
+					"x-codex-primary-window-minutes": "300",
+					"x-codex-primary-reset-at": String(nowSeconds() + 5 * 60 * 60),
+				},
+				400,
+			);
+
+			expect((await sendPrompt()).status).toBe(400);
+			expect(mockQuotaExhaustionCalls).toEqual([]);
+		});
+
+		it("persists exhausted headers from a confirmed rate-limit error", async () => {
+			const resetAtSeconds = nowSeconds() + 5 * 60 * 60;
+			respondWith(
+				{
+					"x-codex-primary-used-percent": "100",
+					"x-codex-primary-window-minutes": "300",
+					"x-codex-primary-reset-at": String(resetAtSeconds),
+				},
+				429,
+			);
+			const fetchHelpers = await import("../lib/request/fetch-helpers.js");
+			vi.mocked(fetchHelpers.handleErrorResponse).mockImplementationOnce(async (response) => ({
+				response,
+				rateLimit: { retryAfterMs: 60_000, code: "usage_limit_reached" },
+			}));
+
+			expect((await sendPrompt()).status).toBe(429);
+			expect(mockQuotaExhaustionCalls).toEqual([
+				expect.objectContaining({ resetAtMs: resetAtSeconds * 1000 }),
+			]);
+		});
 	});
 
 	it("persists the selected account before writing TUI quota snapshots", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3964,6 +3964,73 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 		expect(metrics.routingVisibility.accountPoolMode).toBe("strict-unavailable");
 	});
 
+	it("does not record TUI quota cache from a non-authoritative error response", async () => {
+		const previousStateDir = process.env.OPENCODE_STATE_DIR;
+		const stateDir = await mkdtemp(join(tmpdir(), "tui-quota-error-"));
+		process.env.OPENCODE_STATE_DIR = stateDir;
+		const quotaHeaders = {
+			"x-codex-primary-used-percent": "100",
+			"x-codex-primary-window-minutes": "300",
+			"x-codex-secondary-used-percent": "100",
+			"x-codex-secondary-window-minutes": "10080",
+			"x-codex-plan-type": "plus",
+			"x-codex-active-limit": "40",
+		};
+		const sendPrompt = async () => {
+			const { sdk } = await setupPlugin();
+			return sdk.fetch!("https://api.openai.com/v1/chat", {
+				method: "POST",
+				body: JSON.stringify({ model: "gpt-5.1" }),
+			});
+		};
+		try {
+			const { getTuiQuotaCachePath, readTuiQuotaSnapshot } = await import(
+				"../lib/tui-quota-cache.js"
+			);
+			const cachePath = getTuiQuotaCachePath(stateDir);
+
+			// An entitlement-style failure carrying a stale 0%-left snapshot. The
+			// router ignores those headers, so the status line must not report the
+			// account as spent either.
+			globalThis.fetch = vi.fn().mockResolvedValue(
+				new Response(JSON.stringify({ error: { code: "usage_not_included" } }), {
+					status: 400,
+					headers: quotaHeaders,
+				}),
+			);
+			await sendPrompt();
+			for (let attempt = 0; attempt < 20; attempt += 1) {
+				await new Promise((resolve) => setTimeout(resolve, 10));
+			}
+			expect(await readTuiQuotaSnapshot(cachePath)).toBeFalsy();
+
+			// Positive control: the same headers on a served request still land, so
+			// the assertion above is about the authority gate and not a broken write.
+			globalThis.fetch = vi.fn().mockResolvedValue(
+				new Response(JSON.stringify({ content: "test" }), {
+					status: 200,
+					headers: quotaHeaders,
+				}),
+			);
+			await sendPrompt();
+			let snapshot = await readTuiQuotaSnapshot(cachePath);
+			for (let attempt = 0; !snapshot && attempt < 20; attempt += 1) {
+				await new Promise((resolve) => setTimeout(resolve, 10));
+				snapshot = await readTuiQuotaSnapshot(cachePath);
+			}
+			expect(snapshot).toEqual(
+				expect.objectContaining({ source: "headers", planType: "plus" }),
+			);
+		} finally {
+			if (previousStateDir === undefined) {
+				delete process.env.OPENCODE_STATE_DIR;
+			} else {
+				process.env.OPENCODE_STATE_DIR = previousStateDir;
+			}
+			await rm(stateDir, { recursive: true, force: true });
+		}
+	});
+
 	it("records TUI quota cache from successful Codex response headers", async () => {
 		const previousStateDir = process.env.OPENCODE_STATE_DIR;
 		const stateDir = await mkdtemp(join(tmpdir(), "tui-quota-index-"));
@@ -4131,12 +4198,50 @@ describe("OpenAIOAuthPlugin fetch handler", () => {
 			vi.mocked(fetchHelpers.handleErrorResponse).mockImplementationOnce(async (response) => ({
 				response,
 				rateLimit: { retryAfterMs: 60_000, code: "usage_limit_reached" },
+				quotaHeadersAuthoritative: true,
 			}));
 
-			expect((await sendPrompt()).status).toBe(429);
+			// The only account in the pool is now blocked, so the router runs out of
+			// candidates rather than replaying the upstream 429 — the same outcome any
+			// rate limit past the short-retry threshold already produced.
+			expect((await sendPrompt()).status).toBe(503);
 			expect(mockQuotaExhaustionCalls).toEqual([
 				expect.objectContaining({ resetAtMs: resetAtSeconds * 1000 }),
 			]);
+			// The window is spent for the next five hours and the block just written
+			// for it cannot be shortened, so the short 429 retry must not fire: a
+			// second upstream call here would mean the account is serving traffic
+			// while rotation still considers it blocked.
+			expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+		});
+
+		it("ignores exhausted headers on a 429-shaped upstream overload", async () => {
+			respondWith(
+				{
+					"x-codex-primary-used-percent": "100",
+					"x-codex-primary-window-minutes": "300",
+					"x-codex-primary-reset-at": String(nowSeconds() + 5 * 60 * 60),
+				},
+				429,
+			);
+			const fetchHelpers = await import("../lib/request/fetch-helpers.js");
+			vi.mocked(fetchHelpers.handleErrorResponse).mockImplementationOnce(async (response) => ({
+				response,
+				rateLimit: { retryAfterMs: 1_750, code: "server_is_overloaded" },
+				retryAsServerError: true,
+				quotaHeadersAuthoritative: false,
+			}));
+
+			const { resetAllCircuitBreakers } = await import("../lib/circuit-breaker.js");
+			try {
+				await sendPrompt();
+				// A ten-second upstream blip must not park the account until the reset.
+				expect(mockQuotaExhaustionCalls).toEqual([]);
+			} finally {
+				// The overload path feeds the module-level breaker, which outlives this
+				// test and would short-circuit every later request in the file.
+				resetAllCircuitBreakers();
+			}
 		});
 	});
 


### PR DESCRIPTION
## Summary
- only persist exhausted quota headers for successful responses or confirmed rate-limit errors
- avoid blocking an account when unrelated entitlement errors include stale quota headers
- cover both non-rate-limit and confirmed rate-limit error responses

## Tests
- npm test -- --run test/index.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota tracking for successful requests and confirmed rate-limit responses.
  * Prevented entitlement, authentication, server, and overload errors from incorrectly marking accounts as quota-exhausted.
  * Ensured quota reset times are recorded only when usage limits are confirmed.
  * Prevented stale or misleading quota information from causing unnecessarily long backoffs.
  * Accounts with exhausted quota windows now rotate instead of attempting an ineffective short retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this change prevents stale quota headers on entitlement and service errors from blocking healthy accounts.
- records quota state only for successful responses and confirmed usage-limit errors
- keeps durable routing state and tui quota status behind the same authority decision
- preserves long quota resets for genuine 429 responses while allowing overload handling to use bounded delays
- adds focused vitest coverage for entitlement errors, remapped usage-limit responses, overloads, successful responses, and retry behavior

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge.

no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| index.ts | gates tui and durable quota updates on response authority and avoids retrying an account whose confirmed quota window is exhausted. |
| lib/request/fetch-helpers.ts | centralizes quota-header authority and prevents stale codex reset windows from controlling unrelated error backoff. |
| test/fetch-helpers.test.ts | adds vitest coverage for genuine limits, remapped limits, entitlement failures, overloads, and server errors. |
| test/index.test.ts | verifies routing persistence, tui cache behavior, and short-retry suppression across authoritative and non-authoritative responses. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[upstream response] --> B{response successful?}
    B -->|yes| C[record quota headers]
    B -->|no| D[classify normalized error]
    D --> E{confirmed non-overload 429?}
    E -->|yes| C
    E -->|no| F[ignore codex quota snapshot]
    C --> G{quota exhausted?}
    G -->|yes| H[persist block and rotate]
    G -->|no| I[continue normal handling]
    F --> I
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(routing): decide quota-header author..."](https://github.com/ndycode/oc-codex-multi-auth/commit/3ccdb5c40e61a3a8ccee1bd1cb6819e09644738f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57424712)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Account rotation and selection](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/account-rotation-and-selection.md)
- Knowledge Base — [Upstream reliability controls](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/upstream-reliability-controls.md)
- Knowledge Base — [Codex request proxying](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/request-proxying.md)
</details>


<!-- /greptile_comment -->