### PR TITLE
fix(auth): reject state-only authorization input

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -644,7 +644,9 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
                                 return "No authorization code found. Paste the full callback URL (e.g., http://localhost:1455/auth/callback?code=...). If browser callback keeps failing, retry with Device Code.";
                         }
                         if (!parsed.state) {
-                                return "Missing OAuth state. Paste the full callback URL including both code and state parameters. If needed, retry with Device Code.";
+                                return parsed.source === "raw"
+                                        ? "That is a bare authorization code. This flow needs the full callback URL, including the state parameter (e.g., http://localhost:1455/auth/callback?code=...&state=...). If needed, retry with Device Code."
+                                        : "Missing OAuth state. Paste the full callback URL including both code and state parameters. If needed, retry with Device Code.";
                         }
                         if (parsed.state !== expectedState) {
                                 return "OAuth state mismatch. Restart login and paste the callback URL generated for this login attempt, or retry with Device Code.";

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -1,5 +1,5 @@
 import { randomBytes, webcrypto } from "node:crypto";
-import type { PKCEPair, AuthorizationFlow, TokenResult, ParsedAuthInput, JWTPayload } from "../types.js";
+import type { PKCEPair, AuthorizationFlow, TokenResult, JWTPayload } from "../types.js";
 import { logError } from "../logger.js";
 import {
 	OAUTH_CALLBACK_PATH,
@@ -23,6 +23,28 @@ export const TOKEN_URL = "https://auth.openai.com/oauth/token";
 // 127.0.0.1 loopback interface for local-only listening.
 export const REDIRECT_URI = `http://localhost:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`;
 
+export type AuthorizationInputParseResult =
+	| {
+		readonly source: "raw";
+		readonly code: string | undefined;
+		readonly state: undefined;
+	}
+	| {
+		readonly source: "url";
+		readonly code: string | undefined;
+		readonly state: string | undefined;
+	}
+	| {
+		readonly source: "query";
+		readonly code: string | undefined;
+		readonly state: string | undefined;
+	}
+	| {
+		readonly source: "fragment";
+		readonly code: string | undefined;
+		readonly state: string | undefined;
+	};
+
 /**
  * Generate a random state value for OAuth flow
  * @returns Random hex string
@@ -36,42 +58,63 @@ export function createState(): string {
  * @param input - User input (URL, code#state, or just code)
  * @returns Parsed authorization data
  */
-export function parseAuthorizationInput(input: string): ParsedAuthInput {
+export function parseAuthorizationInput(input: string): AuthorizationInputParseResult {
 	const value = (input || "").trim();
-	if (!value) return {};
+	if (!value) {
+		return { source: "raw", code: undefined, state: undefined };
+	}
 
 	try {
 		const url = new URL(value);
-		let code = url.searchParams.get("code") ?? undefined;
-		let state = url.searchParams.get("state") ?? undefined;
-
-		// Fallback: check hash if not found in searchParams (for #code=... format)
-		if (url.hash && (!code || !state)) {
-			const hashValue = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
-			const hashParams = new URLSearchParams(hashValue);
-			code = code ?? hashParams.get("code") ?? undefined;
-			state = state ?? hashParams.get("state") ?? undefined;
+		const fragmentParams = new URLSearchParams(url.hash.slice(1));
+		return {
+			source: "url",
+			code: url.searchParams.get("code") ?? fragmentParams.get("code") ?? undefined,
+			state: url.searchParams.get("state") ?? fragmentParams.get("state") ?? undefined,
+		};
+	} catch (error) {
+		if (!(error instanceof TypeError)) {
+			throw error;
 		}
+	}
 
-		if (code || state) {
-			return { code, state };
+	if (value.startsWith("#")) {
+		const fragmentParams = new URLSearchParams(value.slice(1));
+		if (fragmentParams.has("code") || fragmentParams.has("state")) {
+			return {
+				source: "fragment",
+				code: fragmentParams.get("code") ?? undefined,
+				state: fragmentParams.get("state") ?? undefined,
+			};
 		}
-	} catch {
-		// Invalid URL, try other parsing methods
+		return { source: "fragment", code: undefined, state: value.slice(1) };
 	}
 
 	if (value.includes("#")) {
-		const [code, state] = value.split("#", 2);
-		return { code, state };
+		try {
+			const fragmentUrl = new URL(value, "https://authorization-input.invalid/");
+			return {
+				source: "fragment",
+				code: fragmentUrl.pathname.slice(1) || undefined,
+				state: fragmentUrl.hash.slice(1),
+			};
+		} catch (error) {
+			if (!(error instanceof TypeError)) {
+				throw error;
+			}
+		}
 	}
-	if (value.includes("code=")) {
-		const params = new URLSearchParams(value);
+
+	const params = new URLSearchParams(value);
+	if (params.has("code") || params.has("state")) {
 		return {
+			source: "query",
 			code: params.get("code") ?? undefined,
 			state: params.get("state") ?? undefined,
 		};
 	}
-	return { code: value };
+
+	return { source: "raw", code: value, state: undefined };
 }
 
 /**

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -23,6 +23,14 @@ export const TOKEN_URL = "https://auth.openai.com/oauth/token";
 // 127.0.0.1 loopback interface for local-only listening.
 export const REDIRECT_URI = `http://localhost:${OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`;
 
+/**
+ * Classification of manually pasted authorization input.
+ *
+ * `raw` means the value could not be read as a callback URL, query string, or
+ * fragment, so it is returned byte for byte as an opaque authorization code and
+ * never carries state. Every other source is structured callback input, where
+ * `code` and `state` are exactly what the callback supplied.
+ */
 export type AuthorizationInputParseResult =
 	| {
 		readonly source: "raw";
@@ -30,20 +38,54 @@ export type AuthorizationInputParseResult =
 		readonly state: undefined;
 	}
 	| {
-		readonly source: "url";
-		readonly code: string | undefined;
-		readonly state: string | undefined;
-	}
-	| {
-		readonly source: "query";
-		readonly code: string | undefined;
-		readonly state: string | undefined;
-	}
-	| {
-		readonly source: "fragment";
+		readonly source: "url" | "query" | "fragment";
 		readonly code: string | undefined;
 		readonly state: string | undefined;
 	};
+
+// An authorization code is opaque and may contain a colon, so a value that only
+// looks like a URL ("ac:1a2b3c") must fall back to the raw path instead of being
+// reported as a callback that carries no code.
+const ABSOLUTE_URL_PREFIX = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+
+// A query string opens with a parameter name followed by "=". Anything else
+// ("Zm9vYmFy&state=x") is an opaque code that happens to contain "&".
+const QUERY_STRING_PREFIX = /^[^\s&=?#/]+=/;
+
+/**
+ * Parse a URL, reporting failure as undefined instead of throwing.
+ *
+ * Every rejection is treated the same on purpose: this runs inside the
+ * interactive login prompt, where an unexpected error class must degrade to
+ * "treat the value as a raw code" rather than escape the prompt.
+ */
+function tryParseUrl(value: string): URL | undefined {
+	try {
+		return new URL(value);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Read `code` and `state` from a callback, preferring the query string and
+ * falling back to the fragment for whichever value the query omitted.
+ */
+function readCallbackParams(
+	query: URLSearchParams,
+	fragment: string,
+): { code: string | undefined; state: string | undefined } {
+	const code = query.get("code") ?? undefined;
+	const state = query.get("state") ?? undefined;
+	if (!fragment || (code !== undefined && state !== undefined)) {
+		return { code, state };
+	}
+	const fragmentParams = new URLSearchParams(fragment);
+	return {
+		code: code ?? fragmentParams.get("code") ?? undefined,
+		state: state ?? fragmentParams.get("state") ?? undefined,
+	};
+}
 
 /**
  * Generate a random state value for OAuth flow
@@ -54,9 +96,17 @@ export function createState(): string {
 }
 
 /**
- * Parse authorization code and state from user input
- * @param input - User input (URL, code#state, or just code)
- * @returns Parsed authorization data
+ * Parse the authorization code and state out of manually pasted input.
+ *
+ * Accepts a full callback URL (values in the query string, in the fragment, or
+ * split across both), a callback URL pasted without its scheme, a bare query
+ * string, a bare `#code=...&state=...` fragment, the `code#state` shorthand,
+ * and an opaque authorization code on its own. Values are returned exactly as
+ * pasted: the shorthand and raw paths never percent-encode or normalise them.
+ *
+ * @param input - User input (callback URL, query string, fragment, code#state, or a bare code)
+ * @returns The parsed values and the `source` they were recognised from, where
+ *   `source: "raw"` marks an opaque code that carries no callback state
  */
 export function parseAuthorizationInput(input: string): AuthorizationInputParseResult {
 	const value = (input || "").trim();
@@ -64,17 +114,13 @@ export function parseAuthorizationInput(input: string): AuthorizationInputParseR
 		return { source: "raw", code: undefined, state: undefined };
 	}
 
-	try {
-		const url = new URL(value);
-		const fragmentParams = new URLSearchParams(url.hash.slice(1));
-		return {
-			source: "url",
-			code: url.searchParams.get("code") ?? fragmentParams.get("code") ?? undefined,
-			state: url.searchParams.get("state") ?? fragmentParams.get("state") ?? undefined,
-		};
-	} catch (error) {
-		if (!(error instanceof TypeError)) {
-			throw error;
+	const url = tryParseUrl(value);
+	if (url) {
+		const { code, state } = readCallbackParams(url.searchParams, url.hash.slice(1));
+		// Without a "scheme://" prefix this may be an opaque code that merely
+		// parsed as a URL, so only claim it when it actually carried a value.
+		if (code !== undefined || state !== undefined || ABSOLUTE_URL_PREFIX.test(value)) {
+			return { source: "url", code, state };
 		}
 	}
 
@@ -87,31 +133,47 @@ export function parseAuthorizationInput(input: string): AuthorizationInputParseR
 				state: fragmentParams.get("state") ?? undefined,
 			};
 		}
-		return { source: "fragment", code: undefined, state: value.slice(1) };
+		// "#abc123" names no parameter. The prompt asks for a code, so return it
+		// as one rather than filing it under state where it can never match.
+		return { source: "raw", code: value.slice(1) || undefined, state: undefined };
 	}
 
-	if (value.includes("#")) {
-		try {
-			const fragmentUrl = new URL(value, "https://authorization-input.invalid/");
-			return {
-				source: "fragment",
-				code: fragmentUrl.pathname.slice(1) || undefined,
-				state: fragmentUrl.hash.slice(1),
-			};
-		} catch (error) {
-			if (!(error instanceof TypeError)) {
-				throw error;
-			}
+	// Callback URL pasted without its scheme, e.g. "127.0.0.1:1455/auth/callback?code=...".
+	const queryIndex = value.indexOf("?");
+	if (queryIndex >= 0) {
+		const afterQuery = value.slice(queryIndex + 1);
+		const boundary = afterQuery.indexOf("#");
+		const { code, state } = readCallbackParams(
+			new URLSearchParams(boundary >= 0 ? afterQuery.slice(0, boundary) : afterQuery),
+			boundary >= 0 ? afterQuery.slice(boundary + 1) : "",
+		);
+		if (code !== undefined || state !== undefined) {
+			return { source: "url", code, state };
 		}
 	}
 
-	const params = new URLSearchParams(value);
-	if (params.has("code") || params.has("state")) {
+	// "code#state" shorthand, split on the raw bytes. Routing this through URL
+	// would percent-encode the values, collapse "..", and truncate at "?". A
+	// value that looks like a URL but failed to parse is a malformed URL rather
+	// than a shorthand, so it is left for the raw path below.
+	const fragmentIndex = value.indexOf("#");
+	if (fragmentIndex >= 0 && !ABSOLUTE_URL_PREFIX.test(value)) {
 		return {
-			source: "query",
-			code: params.get("code") ?? undefined,
-			state: params.get("state") ?? undefined,
+			source: "fragment",
+			code: value.slice(0, fragmentIndex) || undefined,
+			state: value.slice(fragmentIndex + 1),
 		};
+	}
+
+	if (QUERY_STRING_PREFIX.test(value)) {
+		const params = new URLSearchParams(value);
+		if (params.has("code") || params.has("state")) {
+			return {
+				source: "query",
+				code: params.get("code") ?? undefined,
+				state: params.get("state") ?? undefined,
+			};
+		}
 	}
 
 	return { source: "raw", code: value, state: undefined };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -66,11 +66,6 @@ export interface AuthorizationFlow {
 	url: string;
 }
 
-export interface ParsedAuthInput {
-	code?: string;
-	state?: string;
-}
-
 /**
  * JWT payload with ChatGPT account info
  */

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -55,6 +55,36 @@ describe('Auth Module', () => {
 				expected: { source: 'fragment', code: 'abc123', state: 'xyz789' },
 			},
 			{
+				name: 'code#state shorthand whose code contains a space',
+				input: 'abc def#xyz789',
+				expected: { source: 'fragment', code: 'abc def', state: 'xyz789' },
+			},
+			{
+				name: 'code#state shorthand whose code contains a backslash',
+				input: 'abc\\def#xyz789',
+				expected: { source: 'fragment', code: 'abc\\def', state: 'xyz789' },
+			},
+			{
+				name: 'code#state shorthand whose code contains dot segments',
+				input: 'a/../b#xyz789',
+				expected: { source: 'fragment', code: 'a/../b', state: 'xyz789' },
+			},
+			{
+				name: 'code#state shorthand whose code opens with a double slash',
+				input: '//abc#xyz789',
+				expected: { source: 'fragment', code: '//abc', state: 'xyz789' },
+			},
+			{
+				name: 'code#state shorthand whose code contains a question mark',
+				input: 'abc?x#xyz789',
+				expected: { source: 'fragment', code: 'abc?x', state: 'xyz789' },
+			},
+			{
+				name: 'code#state shorthand whose state contains a space',
+				input: 'abc123#xyz 789',
+				expected: { source: 'fragment', code: 'abc123', state: 'xyz 789' },
+			},
+			{
 				name: 'raw code',
 				input: 'abc123',
 				expected: { source: 'raw', code: 'abc123', state: undefined },
@@ -63,6 +93,26 @@ describe('Auth Module', () => {
 				name: 'opaque raw code containing equals signs',
 				input: 'opaque=part==',
 				expected: { source: 'raw', code: 'opaque=part==', state: undefined },
+			},
+			{
+				name: 'opaque raw code containing a colon',
+				input: 'ac:1a2b3c',
+				expected: { source: 'raw', code: 'ac:1a2b3c', state: undefined },
+			},
+			{
+				name: 'opaque raw code shaped like a non-special URL scheme',
+				input: 'v2:abcdef',
+				expected: { source: 'raw', code: 'v2:abcdef', state: undefined },
+			},
+			{
+				name: 'opaque raw code followed by an unrelated ampersand parameter',
+				input: 'Zm9vYmFy&state=YmFy',
+				expected: { source: 'raw', code: 'Zm9vYmFy&state=YmFy', state: undefined },
+			},
+			{
+				name: 'fragment carrying a bare value rather than parameters',
+				input: '#abc123',
+				expected: { source: 'raw', code: 'abc123', state: undefined },
 			},
 			{
 				name: 'malformed URL-shaped raw code',
@@ -115,9 +165,9 @@ describe('Auth Module', () => {
 				expected: { source: 'fragment', code: 'abc123', state: '' },
 			},
 			{
-				name: 'state-only fragment shorthand',
-				input: '#abc123',
-				expected: { source: 'fragment', code: undefined, state: 'abc123' },
+				name: 'fragment separator carrying no value',
+				input: '#',
+				expected: { source: 'raw', code: undefined, state: undefined },
 			},
 			{
 				name: 'URL query code with fragment state fallback',
@@ -129,6 +179,36 @@ describe('Auth Module', () => {
 				input: 'http://localhost:1455/auth/callback?state=querystate#code=hashcode',
 				expected: { source: 'url', code: 'hashcode', state: 'querystate' },
 			},
+			{
+				name: 'URL query parameters taking precedence over fragment parameters',
+				input: 'http://localhost:1455/auth/callback?code=querycode&state=querystate#code=hashcode&state=hashstate',
+				expected: { source: 'url', code: 'querycode', state: 'querystate' },
+			},
+			{
+				name: 'URL carrying only a fragment state',
+				input: 'http://localhost:1455/auth/callback#state=hashstate',
+				expected: { source: 'url', code: undefined, state: 'hashstate' },
+			},
+			{
+				name: 'URL carrying only a fragment code',
+				input: 'http://localhost:1455/auth/callback#code=abc123',
+				expected: { source: 'url', code: 'abc123', state: undefined },
+			},
+			{
+				name: 'URL whose fragment names no parameter',
+				input: 'http://localhost:1455/auth/callback#invalid',
+				expected: { source: 'url', code: undefined, state: undefined },
+			},
+			{
+				name: 'callback URL pasted without its scheme',
+				input: 'localhost:1455/auth/callback?code=abc123&state=xyz789',
+				expected: { source: 'url', code: 'abc123', state: 'xyz789' },
+			},
+			{
+				name: 'callback URL pasted without its scheme against a numeric host',
+				input: '127.0.0.1:1455/auth/callback?code=abc123&state=xyz789',
+				expected: { source: 'url', code: 'abc123', state: 'xyz789' },
+			},
 		])('classifies $name without changing supplied values', ({ input, expected }) => {
 			// Given the structured authorization input and expected parse result above
 			// When
@@ -138,7 +218,7 @@ describe('Auth Module', () => {
 			expect(result).toEqual(expected);
 		});
 
-		it.each(['', '  '])('classifies empty input as an empty raw value', (input) => {
+		it.each(['', '  '])('classifies empty input as an empty raw value for %j', (input) => {
 			// Given empty or whitespace-only authorization input
 			// When
 			const result = parseAuthorizationInput(input);

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -28,102 +28,133 @@ describe('Auth Module', () => {
 	});
 
 	describe('parseAuthorizationInput', () => {
-		it('should parse full OAuth callback URL', () => {
-			const input = 'http://localhost:1455/auth/callback?code=abc123&state=xyz789';
+		it.each([
+			{
+				name: 'full OAuth callback URL with query parameters',
+				input: 'http://localhost:1455/auth/callback?code=abc123&state=xyz789',
+				expected: { source: 'url', code: 'abc123', state: 'xyz789' },
+			},
+			{
+				name: 'full OAuth callback URL with fragment parameters',
+				input: 'http://localhost:1455/auth/callback#code=abc123&state=xyz789',
+				expected: { source: 'url', code: 'abc123', state: 'xyz789' },
+			},
+			{
+				name: 'query string',
+				input: 'code=abc123&state=xyz789',
+				expected: { source: 'query', code: 'abc123', state: 'xyz789' },
+			},
+			{
+				name: 'bare fragment parameters',
+				input: '#code=abc123&state=xyz789',
+				expected: { source: 'fragment', code: 'abc123', state: 'xyz789' },
+			},
+			{
+				name: 'code#state shorthand',
+				input: 'abc123#xyz789',
+				expected: { source: 'fragment', code: 'abc123', state: 'xyz789' },
+			},
+			{
+				name: 'raw code',
+				input: 'abc123',
+				expected: { source: 'raw', code: 'abc123', state: undefined },
+			},
+			{
+				name: 'opaque raw code containing equals signs',
+				input: 'opaque=part==',
+				expected: { source: 'raw', code: 'opaque=part==', state: undefined },
+			},
+			{
+				name: 'malformed URL-shaped raw code',
+				input: 'https://[invalid',
+				expected: { source: 'raw', code: 'https://[invalid', state: undefined },
+			},
+			{
+				name: 'malformed URL-shaped raw code containing a fragment separator',
+				input: 'https://[invalid#state',
+				expected: { source: 'raw', code: 'https://[invalid#state', state: undefined },
+			},
+		])('preserves $name input', ({ input, expected }) => {
+			// Given the authorization input and expected parse result above
+			// When
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'abc123', state: 'xyz789' });
+
+			// Then
+			expect(result).toEqual(expected);
 		});
 
-		it('should parse code#state format', () => {
-			const input = 'abc123#xyz789';
+		it.each([
+			{
+				name: 'URL with unrelated parameters',
+				input: 'http://localhost:1455/auth/callback?error=access_denied',
+				expected: { source: 'url', code: undefined, state: undefined },
+			},
+			{
+				name: 'URL with code and omitted state',
+				input: 'http://localhost:1455/auth/callback?code=abc123',
+				expected: { source: 'url', code: 'abc123', state: undefined },
+			},
+			{
+				name: 'URL with code and empty state',
+				input: 'http://localhost:1455/auth/callback?code=abc123&state=',
+				expected: { source: 'url', code: 'abc123', state: '' },
+			},
+			{
+				name: 'code-only query',
+				input: 'code=abc123',
+				expected: { source: 'query', code: 'abc123', state: undefined },
+			},
+			{
+				name: 'state-only query',
+				input: 'state=test-state',
+				expected: { source: 'query', code: undefined, state: 'test-state' },
+			},
+			{
+				name: 'code with empty shorthand state',
+				input: 'abc123#',
+				expected: { source: 'fragment', code: 'abc123', state: '' },
+			},
+			{
+				name: 'state-only fragment shorthand',
+				input: '#abc123',
+				expected: { source: 'fragment', code: undefined, state: 'abc123' },
+			},
+			{
+				name: 'URL query code with fragment state fallback',
+				input: 'http://localhost:1455/auth/callback?code=querycode#state=hashstate',
+				expected: { source: 'url', code: 'querycode', state: 'hashstate' },
+			},
+			{
+				name: 'URL query state with fragment code fallback',
+				input: 'http://localhost:1455/auth/callback?state=querystate#code=hashcode',
+				expected: { source: 'url', code: 'hashcode', state: 'querystate' },
+			},
+		])('classifies $name without changing supplied values', ({ input, expected }) => {
+			// Given the structured authorization input and expected parse result above
+			// When
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'abc123', state: 'xyz789' });
+
+			// Then
+			expect(result).toEqual(expected);
 		});
 
-		it('should parse query string format', () => {
-			const input = 'code=abc123&state=xyz789';
+		it.each(['', '  '])('classifies empty input as an empty raw value', (input) => {
+			// Given empty or whitespace-only authorization input
+			// When
 			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'abc123', state: 'xyz789' });
+
+			// Then
+			expect(result).toEqual({ source: 'raw', code: undefined, state: undefined });
 		});
 
-		it('should parse query string with code= only (no state param)', () => {
-			const input = 'code=abc123';
-			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'abc123', state: undefined });
+		it.each([undefined, null])('retains the runtime empty-input fallback for %s', (input) => {
+			// Given a nullish value from an untyped JavaScript caller
+			// When
+			const result = parseAuthorizationInput(input as unknown as string);
+
+			// Then
+			expect(result).toEqual({ source: 'raw', code: undefined, state: undefined });
 		});
-
-		it('should parse URL with fragment parameters (#code=...)', () => {
-			const input = 'http://localhost:1455/auth/callback#code=abc123&state=xyz789';
-			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'abc123', state: 'xyz789' });
-		});
-
-		it('should prefer query params over hash params when both exist', () => {
-			const input = 'http://localhost:1455/auth/callback?code=querycode&state=querystate#code=hashcode&state=hashstate';
-			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'querycode', state: 'querystate' });
-		});
-
-		it('should fallback to hash for missing state in query', () => {
-			const input = 'http://localhost:1455/auth/callback?code=querycode#state=hashstate';
-			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'querycode', state: 'hashstate' });
-		});
-
-		it('should fallback to hash for missing code in query', () => {
-			const input = 'http://localhost:1455/auth/callback?state=querystate#code=hashcode';
-			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'hashcode', state: 'querystate' });
-		});
-
-		it('should handle URL with hash but without # prefix', () => {
-			const input = 'http://localhost:1455/auth/callback#code=abc123';
-			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'abc123', state: undefined });
-		});
-
-		it('should return code and state when only state is in hash (line 44 coverage)', () => {
-			const input = 'http://localhost:1455/auth/callback?code=querycode#state=hashstate';
-			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: 'querycode', state: 'hashstate' });
-		});
-
-		it('should return state only when only state is in hash and no code (line 44 coverage)', () => {
-			const input = 'http://localhost:1455/auth/callback#state=hashstate';
-			const result = parseAuthorizationInput(input);
-			expect(result).toEqual({ code: undefined, state: 'hashstate' });
-		});
-
-	it('should parse code only', () => {
-		const input = 'abc123';
-		const result = parseAuthorizationInput(input);
-		expect(result).toEqual({ code: 'abc123' });
-	});
-
-	it('should parse code= query string without state (line 58 state undefined branch)', () => {
-		const input = 'code=abc123';
-		const result = parseAuthorizationInput(input);
-		expect(result).toEqual({ code: 'abc123', state: undefined });
-	});
-
-		it('should return empty object for empty input', () => {
-			const result = parseAuthorizationInput('');
-			expect(result).toEqual({});
-		});
-
-		it('should handle whitespace', () => {
-			const result = parseAuthorizationInput('  ');
-			expect(result).toEqual({});
-		});
-
-	it('should fall through to # split when valid URL has hash with no code/state params (line 44 false branch)', () => {
-		// URL parses successfully but hash contains no code= or state= params
-		// Line 44's false branch is hit (code && state both undefined)
-		// Falls through to line 51 which splits on #
-		const input = 'http://localhost:1455/auth/callback#invalid';
-		const result = parseAuthorizationInput(input);
-		expect(result).toEqual({ code: 'http://localhost:1455/auth/callback', state: 'invalid' });
-	});
 	});
 
 	describe('decodeJWT', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -25,42 +25,45 @@ vi.mock("@opencode-ai/plugin/tool", () => {
 	return { tool };
 });
 
-vi.mock("../lib/auth/auth.js", () => ({
-	createAuthorizationFlow: vi.fn(async () => ({
-		pkce: { verifier: "test-verifier", challenge: "test-challenge" },
-		state: "test-state",
-		url: "https://auth.openai.com/test",
-	})),
-	exchangeAuthorizationCode: vi.fn(async () => ({
-		type: "success" as const,
-		access: "access-token",
-		refresh: "refresh-token",
-		expires: Date.now() + 3600_000,
-		idToken: "id-token",
-	})),
-	parseAuthorizationInput: vi.fn((input: string) => {
-		const codeMatch = input.match(/code=([^&]+)/);
-		const stateMatch = input.match(/state=([^&#]+)/);
-		return {
-			code: codeMatch?.[1],
-			state: stateMatch?.[1],
-		};
-	}),
-	decodeJWT: vi.fn((token: string) => {
-		try {
-			const payload = token.split(".")[1];
-			return payload
-				? (JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Record<
-						string,
-						unknown
-					>)
-				: null;
-		} catch {
-			return null;
-		}
-	}),
-	REDIRECT_URI: "http://localhost:1455/auth/callback",
-}));
+vi.mock("../lib/auth/auth.js", async () => {
+	// parseAuthorizationInput is pure, so the manual-flow tests run the real
+	// classifier rather than a hand-written stand-in. A stand-in cannot be
+	// type-checked against the module and would silently drift from its
+	// `source` contract, which is what index.ts branches on.
+	const actual = await vi.importActual<typeof import("../lib/auth/auth.js")>(
+		"../lib/auth/auth.js",
+	);
+
+	return {
+		createAuthorizationFlow: vi.fn(async () => ({
+			pkce: { verifier: "test-verifier", challenge: "test-challenge" },
+			state: "test-state",
+			url: "https://auth.openai.com/test",
+		})),
+		exchangeAuthorizationCode: vi.fn(async () => ({
+			type: "success" as const,
+			access: "access-token",
+			refresh: "refresh-token",
+			expires: Date.now() + 3600_000,
+			idToken: "id-token",
+		})),
+		parseAuthorizationInput: vi.fn(actual.parseAuthorizationInput),
+		decodeJWT: vi.fn((token: string) => {
+			try {
+				const payload = token.split(".")[1];
+				return payload
+					? (JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Record<
+							string,
+							unknown
+						>)
+					: null;
+			} catch {
+				return null;
+			}
+		}),
+		REDIRECT_URI: "http://localhost:1455/auth/callback",
+	};
+});
 
 // Only the refresh lease is stubbed: `getStoragePath()` is mocked to a path that
 // does not exist, and acquiring a real cross-process lockfile there would create
@@ -750,6 +753,31 @@ describe("OpenAIOAuthPlugin", () => {
 			const result = await flow.callback(invalidInput);
 			expect(result.type).toBe("failed");
 			expect(result.reason).toBe("invalid_response");
+			expect(vi.mocked(authModule.exchangeAuthorizationCode)).not.toHaveBeenCalled();
+		});
+
+		it("tells the user to paste the callback URL when only a bare code is supplied", async () => {
+			const authModule = await import("../lib/auth/auth.js");
+			const manualMethod = plugin.auth.methods[2] as unknown as {
+				authorize: () => Promise<{
+					validate: (input: string) => string | undefined;
+					callback: (input: string) => Promise<{ type: string; reason?: string }>;
+				}>;
+			};
+
+			const flow = await manualMethod.authorize();
+			// A bare code carries no state, so it cannot be bound to this login
+			// attempt. The message has to name the missing part, not just repeat
+			// the generic "missing OAuth state" wording used for callback input.
+			const bareCode = "abc123";
+
+			const message = flow.validate(bareCode);
+			expect(message).toContain("bare authorization code");
+			expect(message).toContain("state");
+			expect(flow.validate("state=test-state")).toContain("No authorization code found");
+
+			const result = await flow.callback(bareCode);
+			expect(result.type).toBe("failed");
 			expect(vi.mocked(authModule.exchangeAuthorizationCode)).not.toHaveBeenCalled();
 		});
 


### PR DESCRIPTION
<!-- Maintainer note: the anti-slop canary token is configured in .github/workflows/pr-quality.yml under blocked-terms. Keep the template and workflow in sync, and do not put the raw token in contributor-facing files. -->

## Summary

- What changed?
  - Classify authorization input as raw code, URL, query, or fragment.
  - Treat query-shaped input containing either `code` or `state` as structured input.
  - Preserve opaque raw authorization codes, including values containing `=`.
  - Add table-driven coverage for URL/query/fragment input, `code#state`, malformed URLs, raw codes, and state-only callbacks.
- Why is this needed?
  - On Linux, automatic OAuth can open a browser profile for the wrong account. Manual paste is the escape hatch, so it must reliably accept exactly what the user can copy from the browser: either the raw authorization code or the full localhost callback URL.
  - That fallback was not dependable: a valid pasted raw code failed, and full callback URL paste had also failed in prior attempts because the parser could misclassify structured input.
  - A state-only callback previously fell through and was returned as though the entire query string were an authorization code.
  - Callers need the input source to require callback state for structured input while still accepting a raw code without state.

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`
- [ ] Not applicable

Additional verification: `npm run typecheck`; 3,087 tests passed and 1 was skipped.

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue: None.
- Follow-up work or rollout notes: This parser fix is a prerequisite for a separate OAuth UX contribution. No user-facing documentation change is required for this parser-only contract correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorization input parsing now identifies whether values come from a URL, query string, fragment, or raw input.
  * Supports authorization codes and state values provided in URL fragments, including fragment-only and `code#state` formats.
  * Empty or whitespace-only input is explicitly recognized.

* **Bug Fixes**
  * Preserves opaque authorization codes containing equals signs.
  * Avoids misclassifying malformed URL-shaped input as structured data.
  * Provides a clearer message when a bare authorization code is submitted without the required state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->








<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

the pr hardens manual oauth input classification while preserving opaque authorization codes and requiring state for structured callbacks.
- classifies raw codes, urls, queries, fragments, and shorthand input explicitly.
- guards malformed url parsing and rejects state-only callbacks before token exchange.
- updates manual-flow validation and adds table-driven vitest coverage.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge.

no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/auth/auth.ts | introduces guarded, source-aware authorization input parsing and retains the malformed url-plus-fragment regression fix. |
| index.ts | distinguishes bare-code guidance while requiring both code and matching state before token exchange. |
| test/auth.test.ts | adds broad table-driven vitest coverage for raw and structured authorization inputs. |
| test/index.test.ts | uses the real parser in manual-flow tests and verifies state-only and bare-code rejection. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[pasted authorization input] --> B{parse as callback url}
  B -->|valid structured input| C[read query and fragment]
  B -->|invalid or opaque input| D{query, fragment, or shorthand}
  D -->|structured| C
  D -->|opaque| E[return raw code without state]
  C --> F{code and matching state present}
  E --> F
  F -->|yes| G[exchange authorization code]
  F -->|no| H[return validation failure]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(auth): preserve pasted authorization..."](https://github.com/ndycode/oc-codex-multi-auth/commit/7df1b21cadc36f9338a946cae9a700bb3a4db8aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58293354)</sub>

**Context used:**

- Knowledge Base — [Codex authentication](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/authentication.md)
- Knowledge Base — [Interactive login flows](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/interactive-login-flows.md)

<!-- /greptile_comment -->