### PR TITLE
fix(notifications): close three quota-monitor defects found while verifying #239

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,9 @@ ignored on Windows and Linux.
 
 Set `"notifyEveryCheck": true` to show the aggregate quota notification after
 every successful poll interval instead of only when a configured threshold is
-crossed. Set `"thresholds": []` to turn threshold alerts off entirely.
+crossed. Set `"thresholds": []` to turn threshold alerts off entirely; pair it
+with `"notifyEveryCheck": true` or the monitor has nothing to deliver and stops
+polling.
 
 Delivery state lives beside the accounts file the alerts are computed from, so
 OpenCode processes working in the same account scope show only one alert per

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -278,7 +278,10 @@ alerts and are never persisted in notification state.
 Set `notifyEveryCheck` to `true` to deliver the aggregate message after every
 successful poll interval even when no threshold was crossed. Set
 `thresholds` to `[]` to disable threshold alerts entirely; omitting the key
-keeps the `[25, 10, 0]` default. Delivery state is stored beside the accounts
+keeps the `[25, 10, 0]` default. `"thresholds": []` together with
+`"notifyEveryCheck": false` can never produce an alert, so the monitor stops
+polling instead of querying the usage endpoint for every account forever.
+Delivery state is stored beside the accounts
 file the alerts are computed from (`oc-codex-multi-auth-quota-notifications.json`),
 so concurrent OpenCode processes in the same account scope produce only one
 routine alert per interval. With the default `perProjectAccounts`, that scope

--- a/lib/quota-notifications.ts
+++ b/lib/quota-notifications.ts
@@ -278,12 +278,26 @@ export function createQuotaMonitor(overrides: Partial<MonitorDependencies> = {})
 	const check = async (config: QuotaNotificationsConfig, expectedGeneration: number): Promise<void> => {
 		const storage = await dependencies.loadStorage();
 		if (!storage || storage.accounts.length === 0 || disposed || expectedGeneration !== generation) return;
+		// Resolved next to the load that produced `storage`, not after the
+		// fetches: the host flips `setStoragePath` when the project changes, and
+		// this aggregate describes the accounts that were just read.
+		const statePath = getQuotaNotificationStatePath(getStoragePath());
 
 		const indices = deduplicateUsageAccountIndices(storage);
 		const summaries: AccountQuotaSummary[] = [];
-		let credentialsPersisted = false;
+		// Fired at the moment of rotation, not at the end of the check. The
+		// rotated refresh token is already durable on disk, and the host's
+		// cached AccountManager has a 500ms debounced save still holding the old
+		// one; a check over N accounts takes far longer than that, so deferring
+		// this leaves exactly the lost-update window open that it exists to
+		// close. Cheap to call more than once: it is a no-op with no cached
+		// manager.
 		const markCredentialsPersisted = (): void => {
-			credentialsPersisted = true;
+			try {
+				dependencies.onCredentialsPersisted();
+			} catch (error) {
+				logWarn(`Failed to invalidate account cache after a quota refresh: ${(error as Error).message}`);
+			}
 		};
 		for (let offset = 0; offset < indices.length; offset += MAX_CONCURRENCY) {
 			if (disposed || expectedGeneration !== generation) break;
@@ -299,21 +313,10 @@ export function createQuotaMonitor(overrides: Partial<MonitorDependencies> = {})
 				if (summary) summaries.push(summary);
 			}
 		}
-		// Must run even when the tick is aborting: a rotated refresh token is
-		// already durable on disk, and leaving the host's cached AccountManager
-		// holding the old one lets its debounced save clobber the rotation.
-		if (credentialsPersisted) {
-			try {
-				dependencies.onCredentialsPersisted();
-			} catch (error) {
-				logWarn(`Failed to invalidate account cache after a quota refresh: ${(error as Error).message}`);
-			}
-		}
 		if (summaries.length === 0 || disposed || expectedGeneration !== generation) return;
 
 		const now = dependencies.now();
 		const usage = aggregateQuotaUsage(summaries, now);
-		const statePath = getQuotaNotificationStatePath(getStoragePath());
 		const memoryState = memoryStateByPath.get(statePath);
 
 		let claim: DeliveryClaim;
@@ -404,7 +407,11 @@ export function createQuotaMonitor(overrides: Partial<MonitorDependencies> = {})
 		let keepPolling = true;
 		try {
 			const config = dependencies.loadConfig();
-			keepPolling = config.enabled && dependencies.notificationsSupported();
+			// `thresholds: []` with `notifyEveryCheck: false` can never deliver
+			// anything, so polling it would query the usage endpoint for every
+			// account, forever, with no possible output.
+			const canDeliver = config.notifyEveryCheck || config.thresholds.length > 0;
+			keepPolling = config.enabled && canDeliver && dependencies.notificationsSupported();
 			if (keepPolling) await check(config, expectedGeneration);
 		} catch (error) {
 			logDebug(`Quota monitor tick failed: ${(error as Error).message}`);

--- a/test/quota-notification-state.test.ts
+++ b/test/quota-notification-state.test.ts
@@ -57,6 +57,30 @@ describe("quota notification state", () => {
 		});
 	});
 
+	it("treats an unreadable state file as absent instead of throwing", async () => {
+		directory = await fs.mkdtemp(join(tmpdir(), "quota-state-"));
+		const statePath = join(directory, "state.json");
+		await fs.writeFile(statePath, "{ not json", "utf-8");
+
+		expect(await readQuotaNotificationState(statePath)).toBeUndefined();
+
+		// A corrupt file must not wedge the monitor: the next update overwrites
+		// it with a well-formed state.
+		const written = await updateQuotaNotificationState(statePath, (previous) => {
+			expect(previous).toBeUndefined();
+			return {
+				state: { fiveHour: { lastPercent: 10 }, weekly: {}, updatedAt: 5 },
+				result: "recovered",
+			};
+		});
+
+		expect(written).toBe("recovered");
+		expect(await readQuotaNotificationState(statePath)).toMatchObject({
+			fiveHour: { lastPercent: 10 },
+			updatedAt: 5,
+		});
+	});
+
 	it("rejects the obsolete shared-band state shape", async () => {
 		directory = await fs.mkdtemp(join(tmpdir(), "quota-state-"));
 		const statePath = join(directory, "state.json");

--- a/test/quota-notifications-fetch.test.ts
+++ b/test/quota-notifications-fetch.test.ts
@@ -1,0 +1,178 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AccountStorageV3 } from "../lib/storage.js";
+
+const ensureCodexUsageAccessToken = vi.fn();
+const fetchCodexUsage = vi.fn();
+
+// Only the two network/credential seams are stubbed. Everything else in
+// `codex-usage.js` stays real so this exercises the default `fetchSummary`
+// wiring rather than a reimplementation of it.
+vi.mock("../lib/codex-usage.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../lib/codex-usage.js")>();
+	return {
+		...actual,
+		ensureCodexUsageAccessToken: (...args: unknown[]) =>
+			ensureCodexUsageAccessToken(...args) as unknown,
+		fetchCodexUsage: (...args: unknown[]) => fetchCodexUsage(...args) as unknown,
+	};
+});
+
+const { createQuotaMonitor } = await import("../lib/quota-notifications.js");
+const { setStoragePathDirect } = await import("../lib/storage/state.js");
+
+const storage: AccountStorageV3 = {
+	version: 3,
+	accounts: [{ refreshToken: "refresh-1", accountId: "account-1", addedAt: 0, lastUsed: 0 }],
+	activeIndex: 0,
+};
+
+function monitorWith(overrides: Record<string, unknown> = {}) {
+	return createQuotaMonitor({
+		loadConfig: () => ({
+			enabled: true,
+			intervalMs: 1_000,
+			notifyEveryCheck: true,
+			thresholds: [25, 10, 0],
+		}),
+		loadStorage: async () => storage,
+		notificationsSupported: () => true,
+		...overrides,
+	});
+}
+
+describe("default quota fetch path", () => {
+	const directories: string[] = [];
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		const directory = await mkdtemp(join(tmpdir(), "quota-fetch-"));
+		directories.push(directory);
+		setStoragePathDirect(join(directory, "accounts.json"));
+	});
+
+	afterEach(async () => {
+		setStoragePathDirect(null);
+		await Promise.all(directories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+	});
+
+	it("invalidates the account cache as soon as a refresh persists, before the usage call", async () => {
+		const order: string[] = [];
+		ensureCodexUsageAccessToken.mockImplementation(() => {
+			order.push("refresh");
+			return { accessToken: "access-1", refreshed: true, persisted: true };
+		});
+		fetchCodexUsage.mockImplementation(() => {
+			order.push("usage");
+			return {
+				rate_limit: {
+					primary_window: { used_percent: 50, limit_window_seconds: 18_000 },
+					secondary_window: { used_percent: 50, limit_window_seconds: 604_800 },
+				},
+			};
+		});
+		const onCredentialsPersisted = vi.fn(() => order.push("invalidate"));
+
+		await monitorWith({ onCredentialsPersisted, notify: vi.fn().mockResolvedValue(true) }).runNow();
+
+		expect(onCredentialsPersisted).toHaveBeenCalledOnce();
+		expect(order).toEqual(["refresh", "invalidate", "usage"]);
+	});
+
+	it("still invalidates the cache when the usage call fails after a rotation", async () => {
+		ensureCodexUsageAccessToken.mockResolvedValue({
+			accessToken: "access-1",
+			refreshed: true,
+			persisted: true,
+		});
+		fetchCodexUsage.mockRejectedValue(new Error("429 from the usage endpoint"));
+		const onCredentialsPersisted = vi.fn();
+		const notify = vi.fn().mockResolvedValue(true);
+
+		await monitorWith({ onCredentialsPersisted, notify }).runNow();
+
+		// The rotation is durable on disk, so the stale cached AccountManager
+		// must be dropped even though this account produced no usage.
+		expect(onCredentialsPersisted).toHaveBeenCalledOnce();
+		expect(notify).not.toHaveBeenCalled();
+	});
+
+	it("does not invalidate the cache when the token was still valid", async () => {
+		ensureCodexUsageAccessToken.mockResolvedValue({
+			accessToken: "access-1",
+			refreshed: false,
+			persisted: false,
+		});
+		fetchCodexUsage.mockResolvedValue({
+			rate_limit: {
+				primary_window: { used_percent: 90, limit_window_seconds: 18_000 },
+				secondary_window: { used_percent: 10, limit_window_seconds: 604_800 },
+			},
+		});
+		const onCredentialsPersisted = vi.fn();
+		const notify = vi.fn().mockResolvedValue(true);
+
+		await monitorWith({ onCredentialsPersisted, notify }).runNow();
+
+		expect(onCredentialsPersisted).not.toHaveBeenCalled();
+		expect(notify).toHaveBeenCalledWith(
+			"Codex quota status",
+			"5h: 10% | resets unavailable\nWeekly: 90% | resets unavailable",
+		);
+	});
+
+	it("skips an account whose access token carries no resolvable account id", async () => {
+		const anonymous: AccountStorageV3 = {
+			version: 3,
+			accounts: [{ refreshToken: "refresh-2", addedAt: 0, lastUsed: 0 }],
+			activeIndex: 0,
+		};
+		ensureCodexUsageAccessToken.mockResolvedValue({
+			accessToken: "not-a-jwt",
+			refreshed: false,
+			persisted: false,
+		});
+		const notify = vi.fn().mockResolvedValue(true);
+
+		await monitorWith({ loadStorage: async () => anonymous, notify }).runNow();
+
+		expect(fetchCodexUsage).not.toHaveBeenCalled();
+		expect(notify).not.toHaveBeenCalled();
+	});
+
+	it("swallows a refresh failure for one account without aborting the check", async () => {
+		const twoAccounts: AccountStorageV3 = {
+			version: 3,
+			accounts: [
+				{ refreshToken: "refresh-a", accountId: "account-a", addedAt: 0, lastUsed: 0 },
+				{ refreshToken: "refresh-b", accountId: "account-b", addedAt: 0, lastUsed: 0 },
+			],
+			activeIndex: 0,
+		};
+		ensureCodexUsageAccessToken.mockImplementation((params: { account: { accountId?: string } }) => {
+			if (params.account.accountId === "account-a") {
+				throw new Error("Cannot refresh: account has no refresh token");
+			}
+			return { accessToken: "access-b", refreshed: false, persisted: false };
+		});
+		fetchCodexUsage.mockResolvedValue({
+			rate_limit: {
+				primary_window: { used_percent: 20, limit_window_seconds: 18_000 },
+				secondary_window: { used_percent: 20, limit_window_seconds: 604_800 },
+			},
+		});
+		const notify = vi.fn().mockResolvedValue(true);
+
+		await monitorWith({ loadStorage: async () => twoAccounts, notify }).runNow();
+
+		expect(fetchCodexUsage).toHaveBeenCalledOnce();
+		expect(notify).toHaveBeenCalledWith(
+			"Codex quota status",
+			"5h: 80% | resets unavailable\nWeekly: 80% | resets unavailable",
+		);
+	});
+});

--- a/test/quota-notifications.test.ts
+++ b/test/quota-notifications.test.ts
@@ -352,6 +352,21 @@ describe("quota monitor lifecycle", () => {
 		monitor.dispose();
 	});
 
+	it("does not poll a configuration that can never deliver", async () => {
+		const loadStorage = vi.fn().mockResolvedValue(null);
+		const monitor = createQuotaMonitor({
+			// Enabled, but with no thresholds and no every-check alert there is
+			// nothing any check could produce.
+			loadConfig: () => ({ enabled: true, intervalMs: 1_000, notifyEveryCheck: false, thresholds: [] }),
+			loadStorage,
+			notificationsSupported: () => true,
+		});
+
+		await monitor.runNow();
+
+		expect(loadStorage).not.toHaveBeenCalled();
+	});
+
 	it("keeps polling on the configured interval while enabled", async () => {
 		vi.useFakeTimers();
 		const loadStorage = vi.fn().mockResolvedValue(null);
@@ -613,6 +628,36 @@ describe("quota monitor lifecycle", () => {
 		expect(notify).toHaveBeenCalledTimes(2);
 		expect(await readQuotaNotificationState(getQuotaNotificationStatePath(join(directory, "accounts.json"))))
 			.toMatchObject({ weekly: {}, lastDeliveredAt: undefined });
+	});
+
+	it("writes state beside the accounts file the check actually read", async () => {
+		const projectA = await mkdtemp(join(tmpdir(), "quota-monitor-a-"));
+		const projectB = await mkdtemp(join(tmpdir(), "quota-monitor-b-"));
+		tempDirectories.push(projectA, projectB);
+		const accountsA = join(projectA, "accounts.json");
+		const accountsB = join(projectB, "accounts.json");
+		setStoragePathDirect(accountsA);
+
+		const monitor = createQuotaMonitor({
+			loadConfig: () => ({ enabled: true, intervalMs: 1_000, notifyEveryCheck: true, thresholds: [25, 10, 0] }),
+			loadStorage: async () => ({
+				version: 3,
+				accounts: [{ refreshToken: "token", addedAt: 0, lastUsed: 0 }],
+				activeIndex: 0,
+			}),
+			fetchSummary: async () => {
+				// The host switched projects while the fetches were in flight.
+				setStoragePathDirect(accountsB);
+				return accountUsage({ fiveHourUsed: 50, weeklyUsed: 50 });
+			},
+			notify: vi.fn().mockResolvedValue(true),
+			notificationsSupported: () => true,
+		});
+
+		await monitor.runNow();
+
+		expect(await readQuotaNotificationState(getQuotaNotificationStatePath(accountsA))).toBeTruthy();
+		expect(await readQuotaNotificationState(getQuotaNotificationStatePath(accountsB))).toBeUndefined();
 	});
 
 	it("tears the timer down through the shared shutdown drain", () => {


### PR DESCRIPTION
Three defects in the quota monitor merged by #239, found by running the full CI matrix and re-auditing the merged code. Each is pinned by a test that fails on `4be5b49`.

## 1. The account-cache invalidation fired at the end of the check, not at the rotation

#239 added `onCredentialsPersisted` so an unattended refresh cannot be clobbered by the cached `AccountManager`'s debounced save. It was wired one step too late: `markCredentialsPersisted` only set a local flag, and the real callback ran after *every* account had been fetched.

The debounce is 500 ms (`lib/accounts/persistence.ts:258`) and a check over N accounts is N/2 sequential HTTPS round trips, so the lost-update window that fix exists to close was still open for the whole check. It now fires the moment `ensureCodexUsageAccessToken` reports `persisted`, before that account's usage call.

Caught by a new test asserting the call order is `refresh → invalidate → usage`; it observed `refresh → usage → invalidate`.

## 2. A configuration that can never deliver still polled forever

`"thresholds": []` with `"notifyEveryCheck": false` produces no crossings and no periodic alert, so `delivering` is always `false`. The monitor still queried the usage endpoint for every account every 30 minutes, forever, with no possible output.

That combination only became reachable in #239, where an explicitly empty list stopped falling back to `[25, 10, 0]`. The tick now treats "nothing can be delivered" the same as "switched off" and stops rescheduling. Documented in the README and `docs/configuration.md`.

## 3. The state path was resolved after the fetches

`getQuotaNotificationStatePath(getStoragePath())` ran after the whole fetch loop rather than next to the `loadStorage` that produced the aggregate. `index.ts` flips `setStoragePath` when the project changes, so a flip mid-check wrote one project's threshold state into another project's file. It is now captured immediately after the storage load.

## Coverage gap this exposed

The default `fetchSummary` (`fetchUsageForAccount`) had **no direct test coverage at all** — every existing test injects a fake — which is how defect 1 survived review. `test/quota-notifications-fetch.test.ts` stubs only the credential and network seams in `codex-usage.js` via `importOriginal` and drives the real wiring: invalidation ordering, invalidation after a failed usage call, no invalidation when the token was still valid, an unresolvable account id, and one account's refresh failing without aborting the check.

## Verification

Every declared `ci.yml` leg was run by hand, since GitHub Actions has never executed on this repo:

| Leg | Result |
| --- | --- |
| ubuntu Node 20 | 3153 passed, 1 skipped |
| ubuntu Node 22 | 3153 passed, 1 skipped |
| ubuntu Node 24 | 3153 passed, 1 skipped |
| windows Node 20 | 3152 passed, 2 skipped |
| windows Node 24 (local) | 3152 passed, 2 skipped |
| consumer-smoke Node 18 | tarball installs, `status --json` correct, new modules present in `dist/lib/` |
| audit:ci | 0 vulnerabilities |

Plus `actionlint` clean on all four workflows, and 5 consecutive runs of the notification and `multiprocess-refresh` suites with no flakes. On this branch: `npm run typecheck`, `npx eslint . --ext .ts`, `npm run build`, and **3160 passed, 2 skipped, 0 failed** across 128 files.

The three `MaxListenersExceededWarning` lines in a full run are pre-existing (confirmed against `5d461e5`), a vitest module-instance-per-file artifact rather than production behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtTe3LToHYk1mG4zS7RD2G


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Credential updates are now saved immediately when tokens refresh, improving account state consistency.
  * Corrupt notification state files are safely recovered and replaced with valid state.
  * Quota checks stop when notification settings cannot produce alerts.
  * Account caches are refreshed reliably after token rotation, including when usage retrieval fails.
  * Checks continue for other accounts when one account encounters a refresh failure.

* **Documentation**
  * Clarified configuration requirements for disabling threshold alerts and enabling periodic notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr moves token-cache invalidation to the point of credential persistence, stops polling configurations that cannot notify, and captures notification-state paths earlier. it also adds focused vitest coverage and documentation, but the state-path fix retains a narrow project-switch concurrency race.

- invalidates cached account managers before post-refresh usage requests.
- avoids polling when both threshold and periodic notifications are disabled.
- adds default fetch-path, corrupt-state recovery, lifecycle, and project-path tests.

<h3>Confidence Score: 4/5</h3>

the remaining project-switch concurrency race should be fixed before merging because it can persist quota state under the wrong account scope.

asynchronous account loading and the subsequent independent read of mutable global storage state can associate one project's accounts with another project's notification-state file; windows rename handling does not close this race.

**Files Needing Attention:** lib/quota-notifications.ts, test/quota-notifications.test.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/quota-notifications.ts | improves token safety and polling behavior, but its separate post-load global path read leaves a wrong-project state-write race. |
| test/quota-notifications.test.ts | adds lifecycle and project-switch coverage, though the switch occurs after the remaining vulnerable load/path interval. |
| test/quota-notifications-fetch.test.ts | adds direct vitest coverage for default fetch wiring, refresh ordering, failures, and unresolved account ids. |
| test/quota-notification-state.test.ts | verifies recovery from malformed notification-state files. |
| README.md | documents that a non-periodic empty-threshold configuration stops polling. |
| docs/configuration.md | documents the no-delivery polling behavior consistently with the implementation. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant M as quota monitor
    participant L as loadStorage
    participant G as global storage path
    participant H as host project switch
    M->>L: loadStorage()
    L->>G: read project a path
    H->>G: setStoragePath(project b)
    L-->>M: project a accounts
    M->>G: read state path
    G-->>M: project b path
    M->>M: persist project a state under project b
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fquota-monitor-followups%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fquota-monitor-followups%22.%0A%0AGreploop%20ndycode%2Foc-codex-multi-auth%20PR%20%23240%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=ndycode%2Foc-codex-multi-auth&pr=240&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fquota-monitor-followups%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fquota-monitor-followups%22.%0A%0A%23%23%23%20Issue%201%0Alib%2Fquota-notifications.ts%3A284%0AWhen%20the%20active%20project%20changes%20after%20%60loadStorage%60%20reads%20project%20a's%20path%20but%20before%20this%20separate%20global-path%20read%2C%20project%20a's%20accounts%20are%20paired%20with%20project%20b's%20notification-state%20file%2C%20causing%20thresholds%20to%20be%20suppressed%20or%20duplicated%20across%20projects.%20the%20added%20vitest%20switches%20paths%20later%20during%20usage%20fetching%2C%20so%20it%20does%20not%20cover%20this%20concurrency%20window%3B%20windows%20rename%20retries%20also%20do%20not%20make%20these%20reads%20atomic.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ndycode%2Foc-codex-multi-auth&pr=240&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/quota-notifications.ts:284
When the active project changes after `loadStorage` reads project a's path but before this separate global-path read, project a's accounts are paired with project b's notification-state file, causing thresholds to be suppressed or duplicated across projects. the added vitest switches paths later during usage fetching, so it does not cover this concurrency window; windows rename retries also do not make these reads atomic.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(notifications): close three defects ..."](https://github.com/ndycode/oc-codex-multi-auth/commit/8077709e001a8fcab8b395b745233c4ea05f0f07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58605101)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->