### PR TITLE
fix(notifications): show best quota and earliest reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- **Quota notifications now show the pool's best availability.** The 5-hour and weekly lines independently select the highest remaining percentage and earliest reset across enabled accounts, rather than showing the reset belonging to the account with the highest remaining percentage.
+### Added
+- **Quota notifications now surface the pool's earliest reset.** Each 5-hour and weekly line still pairs the highest remaining percentage with that same account's reset, so the pair describes a quota one account actually has. When a different account recovers sooner, that reset is appended as `another account resets ...` rather than replacing the paired one, which would have described a quota no account holds.
 
 ## [6.15.0] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,6 @@ All notable changes to this project will be documented in this file. Dates are I
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-- **Quota notifications now surface the pool's earliest reset.** Each 5-hour and weekly line still pairs the highest remaining percentage with that same account's reset, so the pair describes a quota one account actually has. When a different account recovers sooner, that reset is appended as `another account resets ...` rather than replacing the paired one, which would have described a quota no account holds.
-
 ## [6.15.0] - 2026-08-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file. Dates are I
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Quota notifications now show the pool's best availability.** The 5-hour and weekly lines independently select the highest remaining percentage and earliest reset across enabled accounts, rather than showing the reset belonging to the account with the highest remaining percentage.
+
 ## [6.15.0] - 2026-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -300,11 +300,10 @@ running, it checks all enabled accounts and alerts through Notification Center
 when the best remaining 5-hour or weekly pool quota crosses 25%, 10%, or 0%.
 The feature is disabled by default.
 
-Each line reports the enabled account with the most headroom in that window,
-together with that same account's reset time, so the pair always describes a
-quota that one account actually has. Windows a plan has switched off are
-skipped rather than counted as full. Account identities are omitted for
-readability and lock-screen privacy:
+Each line reports the most headroom available across enabled accounts in that
+window together with the earliest reset across those accounts. Windows a plan
+has switched off are skipped rather than counted as full. Account identities
+are omitted for readability and lock-screen privacy:
 
 ```text
 5h: 10% | resets 22:30

--- a/README.md
+++ b/README.md
@@ -300,13 +300,15 @@ running, it checks all enabled accounts and alerts through Notification Center
 when the best remaining 5-hour or weekly pool quota crosses 25%, 10%, or 0%.
 The feature is disabled by default.
 
-Each line reports the most headroom available across enabled accounts in that
-window together with the earliest reset across those accounts. Windows a plan
-has switched off are skipped rather than counted as full. Account identities
-are omitted for readability and lock-screen privacy:
+Each line reports the enabled account with the most headroom in that window,
+together with that same account's reset time, so the pair always describes a
+quota that one account actually has. When a different account recovers sooner,
+that reset is appended under its own label rather than folded into the first
+one. Windows a plan has switched off are skipped rather than counted as full.
+Account identities are omitted for readability and lock-screen privacy:
 
 ```text
-5h: 10% | resets 22:30
+5h: 10% | resets 02:00 | another account resets 22:30
 Weekly: 72% | resets 22:30 on Aug 30
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,11 +270,12 @@ The sample above intentionally sets `"retryAllAccountsMaxRetries": 3` as a bound
 Quota notifications query each distinct enabled account with bounded
 concurrency. The 5-hour and weekly windows are tracked independently, and each
 threshold alerts once until that window rises above it after a reset. Each line
-reports the account with the most headroom in that window plus that same
-account's reset time, so the percentage and the reset always come from one
-account. A window the plan has switched off reports `used_percent: 0` and is
-skipped rather than scored as a full quota. Account identities are omitted from
-alerts and are never persisted in notification state.
+reports the most headroom across enabled accounts in that window plus the
+earliest reset across those accounts. The percentage and reset may come from
+different accounts. A window the plan has switched off reports
+`used_percent: 0` and is skipped rather than scored as a full quota. Account
+identities are omitted from alerts and are never persisted in notification
+state.
 Set `notifyEveryCheck` to `true` to deliver the aggregate message after every
 successful poll interval even when no threshold was crossed. Set
 `thresholds` to `[]` to disable threshold alerts entirely; omitting the key

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,12 +270,13 @@ The sample above intentionally sets `"retryAllAccountsMaxRetries": 3` as a bound
 Quota notifications query each distinct enabled account with bounded
 concurrency. The 5-hour and weekly windows are tracked independently, and each
 threshold alerts once until that window rises above it after a reset. Each line
-reports the most headroom across enabled accounts in that window plus the
-earliest reset across those accounts. The percentage and reset may come from
-different accounts. A window the plan has switched off reports
-`used_percent: 0` and is skipped rather than scored as a full quota. Account
-identities are omitted from alerts and are never persisted in notification
-state.
+reports the account with the most headroom in that window plus that same
+account's reset time, so the percentage and the reset it is printed with always
+come from one account. When another account recovers earlier, that reset is
+appended as a separate `another account resets ...` clause instead of replacing
+the first one. A window the plan has switched off reports `used_percent: 0` and
+is skipped rather than scored as a full quota. Account identities are omitted
+from alerts and are never persisted in notification state.
 Set `notifyEveryCheck` to `true` to deliver the aggregate message after every
 successful poll interval even when no threshold was crossed. Set
 `thresholds` to `[]` to disable threshold alerts entirely; omitting the key

--- a/lib/quota-notifications.ts
+++ b/lib/quota-notifications.ts
@@ -79,49 +79,34 @@ type MonitorDependencies = {
 };
 
 /**
- * Reduce one quota window across accounts to the single account that has the
- * most room left, reporting that account's own reset time.
- *
- * Two rules matter here:
- *
- *   - A window the plan has switched off is skipped via {@link hasUsageWindow}.
- *     Such a window still reports `used_percent: 0`, so counting it would score
- *     a disabled window as 100% remaining and mask every other account.
- *   - The percentage and the reset time are taken from the *same* account. A
- *     max-percent/min-reset pair describes a quota no account actually has.
+ * Reduce one quota window across accounts to the most remaining quota and the
+ * earliest reset independently. A disabled window is skipped because it can
+ * report `used_percent: 0` and would otherwise mask active windows as 100% full.
  */
 function aggregateWindow(
 	summaries: readonly AccountQuotaSummary[],
 	select: (summary: CodexUsageSummary) => CodexUsageSummary["primary"],
 	now: number,
 ): AggregatedQuotaWindow {
-	let best: { remainingPercent: number; resetAtMs?: number } | undefined;
+	let remainingPercent: number | undefined;
+	let resetAtMs: number | undefined;
 	for (const accountSummary of summaries) {
 		const window = select(accountSummary.usage);
 		if (!hasUsageWindow(window)) continue;
 		const remaining = getUsageLeftPercent(window.usedPercent);
-		if (remaining === undefined) continue;
-		const resetAtMs =
+		if (remaining !== undefined && (remainingPercent === undefined || remaining > remainingPercent)) {
+			remainingPercent = remaining;
+		}
+		if (
 			typeof window.resetAtMs === "number" &&
 			Number.isFinite(window.resetAtMs) &&
-			window.resetAtMs > now
-				? window.resetAtMs
-				: undefined;
-		if (best === undefined || remaining > best.remainingPercent) {
-			best = { remainingPercent: remaining, resetAtMs };
-			continue;
-		}
-		// Tie on headroom: prefer the account that recovers first, and prefer a
-		// known reset over an unknown one.
-		if (
-			remaining === best.remainingPercent &&
-			resetAtMs !== undefined &&
-			(best.resetAtMs === undefined || resetAtMs < best.resetAtMs)
+			window.resetAtMs > now &&
+			(resetAtMs === undefined || window.resetAtMs < resetAtMs)
 		) {
-			best = { remainingPercent: remaining, resetAtMs };
+			resetAtMs = window.resetAtMs;
 		}
 	}
-	return best ? { remainingPercent: best.remainingPercent, resetAtMs: best.resetAtMs } : {};
+	return { remainingPercent, resetAtMs };
 }
 
 export function aggregateQuotaUsage(

--- a/lib/quota-notifications.ts
+++ b/lib/quota-notifications.ts
@@ -32,8 +32,20 @@ const MAX_CONCURRENCY = 2;
 export type QuotaWindowName = "fiveHour" | "weekly";
 
 export interface AggregatedQuotaWindow {
+	/** Headroom of the enabled account with the most room left in this window. */
 	remainingPercent?: number;
+	/**
+	 * Reset time of the account `remainingPercent` was taken from. Always the
+	 * same account, so the pair describes a quota one account actually has.
+	 */
 	resetAtMs?: number;
+	/**
+	 * Earliest reset across every enabled account with usable usage, set only
+	 * when some other account recovers before {@link resetAtMs}. Reported as its
+	 * own value rather than folded into `resetAtMs`, because a max-percent /
+	 * min-reset pair describes a quota no account holds.
+	 */
+	earliestResetAtMs?: number;
 }
 
 export interface AggregatedQuotaUsage {
@@ -45,7 +57,10 @@ export interface QuotaThresholdCrossing {
 	window: QuotaWindowName;
 	threshold: number;
 	remainingPercent: number;
+	/** Reset of the account `remainingPercent` came from; never a different one. */
 	resetAtMs?: number;
+	/** Earliest reset in the pool, when it is not `resetAtMs`. */
+	earliestResetAtMs?: number;
 }
 
 export interface AccountQuotaSummary {
@@ -79,35 +94,71 @@ type MonitorDependencies = {
 };
 
 /**
- * Reduce one quota window across accounts to the most remaining quota and the
- * earliest reset independently. A disabled window is skipped because it can
- * report `used_percent: 0` and would otherwise mask active windows as 100% full.
+ * Reduce one quota window across accounts to the single account that has the
+ * most room left, reporting that account's own reset time, plus the earliest
+ * reset anywhere in the pool.
+ *
+ * Three rules matter here:
+ *
+ *   - A window the plan has switched off is skipped via {@link hasUsageWindow}.
+ *     Such a window still reports `used_percent: 0`, so counting it would score
+ *     a disabled window as 100% remaining and mask every other account.
+ *   - `remainingPercent` and `resetAtMs` are taken from the *same* account. A
+ *     max-percent/min-reset pair describes a quota no account actually has: the
+ *     reader waits for a reset that belongs to a different, exhausted account.
+ *   - The pool's earliest reset is still worth reporting — it is when capacity
+ *     next returns — so it is carried separately in `earliestResetAtMs` and
+ *     rendered under its own label. Only windows with usable usage contribute,
+ *     so a window with a reset but no readable `used_percent` cannot supply one.
  */
 function aggregateWindow(
 	summaries: readonly AccountQuotaSummary[],
 	select: (summary: CodexUsageSummary) => CodexUsageSummary["primary"],
 	now: number,
 ): AggregatedQuotaWindow {
-	let remainingPercent: number | undefined;
-	let resetAtMs: number | undefined;
+	let best: { remainingPercent: number; resetAtMs?: number } | undefined;
+	let earliestResetAtMs: number | undefined;
 	for (const accountSummary of summaries) {
 		const window = select(accountSummary.usage);
 		if (!hasUsageWindow(window)) continue;
 		const remaining = getUsageLeftPercent(window.usedPercent);
 		if (remaining === undefined) continue;
-		if (remainingPercent === undefined || remaining > remainingPercent) {
-			remainingPercent = remaining;
-		}
-		if (
+		const resetAtMs =
 			typeof window.resetAtMs === "number" &&
 			Number.isFinite(window.resetAtMs) &&
-			window.resetAtMs > now &&
-			(resetAtMs === undefined || window.resetAtMs < resetAtMs)
+			window.resetAtMs > now
+				? window.resetAtMs
+				: undefined;
+		if (
+			resetAtMs !== undefined &&
+			(earliestResetAtMs === undefined || resetAtMs < earliestResetAtMs)
 		) {
-			resetAtMs = window.resetAtMs;
+			earliestResetAtMs = resetAtMs;
+		}
+		if (best === undefined || remaining > best.remainingPercent) {
+			best = { remainingPercent: remaining, resetAtMs };
+			continue;
+		}
+		// Tie on headroom: prefer the account that recovers first, and prefer a
+		// known reset over an unknown one.
+		if (
+			remaining === best.remainingPercent &&
+			resetAtMs !== undefined &&
+			(best.resetAtMs === undefined || resetAtMs < best.resetAtMs)
+		) {
+			best = { remainingPercent: remaining, resetAtMs };
 		}
 	}
-	return { remainingPercent, resetAtMs };
+	if (!best) return {};
+	return {
+		remainingPercent: best.remainingPercent,
+		resetAtMs: best.resetAtMs,
+		// Omitted when it is the same instant the best account already reports,
+		// so the message carries one reset unless the pool really has two.
+		...(earliestResetAtMs !== undefined && earliestResetAtMs !== best.resetAtMs
+			? { earliestResetAtMs }
+			: {}),
+	};
 }
 
 export function aggregateQuotaUsage(
@@ -163,6 +214,7 @@ export function transitionQuotaState(
 			threshold: fiveHour.threshold,
 			remainingPercent: usage.fiveHour.remainingPercent,
 			resetAtMs: usage.fiveHour.resetAtMs,
+			earliestResetAtMs: usage.fiveHour.earliestResetAtMs,
 		});
 	}
 	if (weekly.threshold !== undefined && usage.weekly.remainingPercent !== undefined) {
@@ -171,6 +223,7 @@ export function transitionQuotaState(
 			threshold: weekly.threshold,
 			remainingPercent: usage.weekly.remainingPercent,
 			resetAtMs: usage.weekly.resetAtMs,
+			earliestResetAtMs: usage.weekly.earliestResetAtMs,
 		});
 	}
 	return {
@@ -184,14 +237,21 @@ export function transitionQuotaState(
 	};
 }
 
+/**
+ * Render one window. The percentage and the `resets` value come from one
+ * account; the pool's earlier reset, when there is one, gets its own clause so
+ * nothing reads as "this percentage recovers then".
+ */
+function formatQuotaWindow(label: string, window: AggregatedQuotaWindow): string {
+	if (window.remainingPercent === undefined) return `${label}: unavailable`;
+	const reset = formatUsageReset(window.resetAtMs) ?? "unavailable";
+	const earliest = formatUsageReset(window.earliestResetAtMs);
+	const poolClause = earliest ? ` | another account resets ${earliest}` : "";
+	return `${label}: ${window.remainingPercent}% | resets ${reset}${poolClause}`;
+}
+
 export function formatQuotaNotification(usage: AggregatedQuotaUsage): string {
-	const fiveHourLine = usage.fiveHour.remainingPercent !== undefined
-		? `5h: ${usage.fiveHour.remainingPercent}% | resets ${formatUsageReset(usage.fiveHour.resetAtMs) ?? "unavailable"}`
-		: "5h: unavailable";
-	const weeklyLine = usage.weekly.remainingPercent !== undefined
-		? `Weekly: ${usage.weekly.remainingPercent}% | resets ${formatUsageReset(usage.weekly.resetAtMs) ?? "unavailable"}`
-		: "Weekly: unavailable";
-	return `${fiveHourLine}\n${weeklyLine}`;
+	return `${formatQuotaWindow("5h", usage.fiveHour)}\n${formatQuotaWindow("Weekly", usage.weekly)}`;
 }
 
 interface DeliveryClaim {

--- a/lib/quota-notifications.ts
+++ b/lib/quota-notifications.ts
@@ -94,7 +94,8 @@ function aggregateWindow(
 		const window = select(accountSummary.usage);
 		if (!hasUsageWindow(window)) continue;
 		const remaining = getUsageLeftPercent(window.usedPercent);
-		if (remaining !== undefined && (remainingPercent === undefined || remaining > remainingPercent)) {
+		if (remaining === undefined) continue;
+		if (remainingPercent === undefined || remaining > remainingPercent) {
 			remainingPercent = remaining;
 		}
 		if (

--- a/test/quota-notifications.test.ts
+++ b/test/quota-notifications.test.ts
@@ -48,7 +48,7 @@ function accountUsage(options: Parameters<typeof usage>[0]): AccountQuotaSummary
 }
 
 describe("quota notification aggregation", () => {
-	it("reports the account with the most headroom and that same account's reset", () => {
+	it("reports the most headroom and earliest reset independently", () => {
 		const result = aggregateQuotaUsage(
 			[
 				accountUsage({
@@ -67,17 +67,15 @@ describe("quota notification aggregation", () => {
 			1_000_000,
 		);
 		expect(result).toEqual({
-			// Second account: 60% left, resetting at its own 1_500_000.
+			// Second account has both the best quota and earliest reset.
 			fiveHour: {
 				remainingPercent: 60,
 				resetAtMs: 1_500_000,
 			},
-			// First account: 70% left, resetting at its own 3_000_000. Taking the
-			// other account's earlier 2_500_000 here would describe a 70% quota
-			// that recovers at a time no account recovers at.
+			// First account has the best quota; second account resets first.
 			weekly: {
 				remainingPercent: 70,
-				resetAtMs: 3_000_000,
+				resetAtMs: 2_500_000,
 			},
 		});
 	});
@@ -109,15 +107,15 @@ describe("quota notification aggregation", () => {
 		expect(result.weekly.remainingPercent).toBe(60);
 	});
 
-	it("prefers the earliest reset when two accounts tie on headroom", () => {
+	it("selects the earliest reset regardless of headroom", () => {
 		const result = aggregateQuotaUsage(
 			[
-				accountUsage({ fiveHourUsed: 50, fiveHourReset: 3_000 }),
+				accountUsage({ fiveHourUsed: 20, fiveHourReset: 3_000 }),
 				accountUsage({ fiveHourUsed: 50, fiveHourReset: 1_500 }),
 			],
 			1_000_000,
 		);
-		expect(result.fiveHour).toEqual({ remainingPercent: 50, resetAtMs: 1_500_000 });
+		expect(result.fiveHour).toEqual({ remainingPercent: 80, resetAtMs: 1_500_000 });
 	});
 
 	it("ignores expired reset timestamps", () => {

--- a/test/quota-notifications.test.ts
+++ b/test/quota-notifications.test.ts
@@ -48,7 +48,7 @@ function accountUsage(options: Parameters<typeof usage>[0]): AccountQuotaSummary
 }
 
 describe("quota notification aggregation", () => {
-	it("reports the most headroom and earliest reset independently", () => {
+	it("pairs the most headroom with that same account's reset and reports the pool's earliest separately", () => {
 		const result = aggregateQuotaUsage(
 			[
 				accountUsage({
@@ -67,15 +67,20 @@ describe("quota notification aggregation", () => {
 			1_000_000,
 		);
 		expect(result).toEqual({
-			// Second account has both the best quota and earliest reset.
+			// Second account holds both the best quota and the earliest reset, so
+			// there is no second reset to report.
 			fiveHour: {
 				remainingPercent: 60,
 				resetAtMs: 1_500_000,
 			},
-			// First account has the best quota; second account resets first.
+			// First account has the best quota and recovers at its own 3_000_000.
+			// The second account recovers earlier, at 2_500_000, but it is the
+			// 90%-used one: folding its reset into `resetAtMs` would describe a
+			// 70% quota that recovers at a time no account recovers at.
 			weekly: {
 				remainingPercent: 70,
-				resetAtMs: 2_500_000,
+				resetAtMs: 3_000_000,
+				earliestResetAtMs: 2_500_000,
 			},
 		});
 	});
@@ -107,7 +112,7 @@ describe("quota notification aggregation", () => {
 		expect(result.weekly.remainingPercent).toBe(60);
 	});
 
-	it("selects the earliest reset regardless of headroom", () => {
+	it("keeps a lower account's earlier reset out of the headline pair", () => {
 		const result = aggregateQuotaUsage(
 			[
 				accountUsage({ fiveHourUsed: 20, fiveHourReset: 3_000 }),
@@ -115,7 +120,24 @@ describe("quota notification aggregation", () => {
 			],
 			1_000_000,
 		);
-		expect(result.fiveHour).toEqual({ remainingPercent: 80, resetAtMs: 1_500_000 });
+		expect(result.fiveHour).toEqual({
+			remainingPercent: 80,
+			resetAtMs: 3_000_000,
+			earliestResetAtMs: 1_500_000,
+		});
+	});
+
+	it("prefers the earliest reset when two accounts tie on headroom", () => {
+		const result = aggregateQuotaUsage(
+			[
+				accountUsage({ fiveHourUsed: 50, fiveHourReset: 3_000 }),
+				accountUsage({ fiveHourUsed: 50, fiveHourReset: 1_500 }),
+			],
+			1_000_000,
+		);
+		// The tie-break already took the earliest, so nothing is left to report
+		// as a separate pool reset.
+		expect(result.fiveHour).toEqual({ remainingPercent: 50, resetAtMs: 1_500_000 });
 	});
 
 	it("ignores reset timestamps from windows without valid usage", () => {
@@ -158,8 +180,22 @@ describe("quota notification content", () => {
 		};
 		const lines = formatQuotaNotification(aggregate).split("\n");
 		expect(lines).toHaveLength(2);
-		expect(lines[0]).toMatch(/^5h: 8% \| resets .+$/);
-		expect(lines[1]).toMatch(/^Weekly: 72% \| resets .+$/);
+		expect(lines[0]).toMatch(/^5h: 8% \| resets [^|]+$/);
+		expect(lines[1]).toMatch(/^Weekly: 72% \| resets [^|]+$/);
+	});
+
+	it("labels the pool's earlier reset instead of pairing it with the percentage", () => {
+		const lines = formatQuotaNotification({
+			fiveHour: {
+				remainingPercent: 60,
+				resetAtMs: Date.now() + 120_000,
+				earliestResetAtMs: Date.now() + 60_000,
+			},
+			weekly: { remainingPercent: 72, resetAtMs: Date.now() + 120_000 },
+		}).split("\n");
+		expect(lines[0]).toMatch(/^5h: 60% \| resets .+ \| another account resets .+$/);
+		// No second reset in the pool, so no second clause.
+		expect(lines[1]).not.toContain("another account");
 	});
 
 	it("handles a missing quota window", () => {

--- a/test/quota-notifications.test.ts
+++ b/test/quota-notifications.test.ts
@@ -118,6 +118,17 @@ describe("quota notification aggregation", () => {
 		expect(result.fiveHour).toEqual({ remainingPercent: 80, resetAtMs: 1_500_000 });
 	});
 
+	it("ignores reset timestamps from windows without valid usage", () => {
+		const result = aggregateQuotaUsage(
+			[
+				accountUsage({ fiveHourUsed: 50, fiveHourReset: 3_000 }),
+				accountUsage({ fiveHourReset: 1_500 }),
+			],
+			1_000_000,
+		);
+		expect(result.fiveHour).toEqual({ remainingPercent: 50, resetAtMs: 3_000_000 });
+	});
+
 	it("ignores expired reset timestamps", () => {
 		const result = aggregateQuotaUsage(
 			[accountUsage({


### PR DESCRIPTION
## Summary
- select the highest remaining quota and earliest future reset independently for each quota window
- preserve disabled-window and expired-reset filtering
- update tests and documentation for the pool-wide aggregation behavior

## Verification
- `npm test -- quota-notifications`
- `npm test -- doc-parity`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Quota notifications now pair each window’s highest remaining percentage with that account’s reset time.
  * When another account resets sooner, its reset time appears separately instead of replacing the primary account’s reset time.
  * Resets from windows without valid usage and disabled plan windows remain excluded.

* **Documentation**
  * Updated the README and configuration guide with the revised notification behavior and examples.

* **Tests**
  * Added coverage for account pairing, tie-breaking, earlier secondary resets, and notification formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

the pr now reports the best account’s quota and reset together while labeling an earlier reset from another usable account separately.
- filters disabled, expired, and reset-only windows before reset aggregation
- updates notification formatting, documentation, and vitest regression coverage
- leaves concurrency, token handling, and windows filesystem behavior unchanged

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge.

no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/quota-notifications.ts | aggregation now preserves quota/reset pairing and separately exposes the earliest valid pool reset; the previous reset-only-window issue is fixed. |
| test/quota-notifications.test.ts | vitest coverage verifies pairing, tie-breaking, expired resets, reset-only windows, and separate reset formatting. |
| README.md | documentation accurately describes and illustrates the revised notification output. |
| docs/configuration.md | configuration guidance remains aligned with the implemented aggregation behavior. |

</details>

<sub>Reviews (4): Last reviewed commit: ["docs(changelog): drop the Unreleased anc..."](https://github.com/ndycode/oc-codex-multi-auth/commit/74510626cc42140d52f34ed03441c29b924597d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58942067)</sub>

<!-- /greptile_comment -->