### PR TITLE
fix(accounts): stop a disposed manager overwriting the account store

### DIFF
--- a/lib/accounts/persistence.ts
+++ b/lib/accounts/persistence.ts
@@ -32,6 +32,12 @@ export class AccountPersistence {
 	private saveDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private pendingSave: Promise<void> | null = null;
 	private shutdownHandler: (() => Promise<void>) | null = null;
+	/**
+	 * Set by {@link disposeShutdownHandler}. From that point this manager has
+	 * been replaced, so its account list is no longer authoritative and every
+	 * further write degrades to {@link mergeVolatileState}.
+	 */
+	private disposed = false;
 
 	constructor(private readonly state: AccountState) {}
 
@@ -86,6 +92,17 @@ export class AccountPersistence {
 		// account permanently. Adopt any newer on-disk credentials before
 		// persisting.
 		await withAccountStorageTransaction(async (current, persist) => {
+			if (this.disposed) {
+				// Disposal landed while this save was already in flight — after
+				// the timer had fired, so cancelling the timer could not stop it.
+				// Its account list belongs to a manager that has been replaced,
+				// so persisting it wholesale would delete whatever the successor
+				// has since loaded or added. Degrade to the volatile merge, which
+				// keeps the rate-limit and cooldown state this snapshot carries
+				// without touching membership.
+				if (current) await persist(this.mergeVolatileState(current));
+				return;
+			}
 			if (current) {
 				// Before adoptNewerDiskCredentials: for records without workspace
 				// ids the refresh token participates in the identity key, and
@@ -96,6 +113,67 @@ export class AccountPersistence {
 			}
 			await persist(storage);
 		});
+	}
+
+	/**
+	 * Persist only the volatile rotation state this manager holds: rate-limit
+	 * blocks, cooldowns, and last-used stamps, each resolved to whichever side
+	 * runs longer or later.
+	 *
+	 * Account membership, credentials, and the active-index routing are taken
+	 * from `disk` untouched. That is what makes the write safe for a manager
+	 * that has already been replaced: a 429 recorded on it still reaches disk,
+	 * and it cannot delete an account its successor loaded or added.
+	 *
+	 * Live in-memory state is left alone for the same reason
+	 * {@link adoptLongerDiskRateLimits} leaves it alone: a missing block is
+	 * self-correcting from the next response's quota headers.
+	 */
+	private mergeVolatileState(disk: AccountStorageV3): AccountStorageV3 {
+		const now = nowMs();
+		const mineByIdentity = new Map<string, AccountState["accounts"][number]>();
+		for (const account of this.state.accounts) {
+			mineByIdentity.set(getWorkspaceIdentityKey(account), account);
+		}
+
+		return {
+			...disk,
+			accounts: disk.accounts.map((record) => {
+				const mine = mineByIdentity.get(getWorkspaceIdentityKey(record));
+				if (!mine) return record;
+				const merged: AccountMetadataV3 = { ...record };
+
+				// Longest-block-wins per quota key, matching adoptLongerDiskRateLimits.
+				// Only blocks still in the future are carried, so an entry this
+				// manager never pruned cannot resurrect an expired block.
+				let resets: Record<string, number | undefined> | undefined;
+				for (const [key, mineReset] of Object.entries(mine.rateLimitResetTimes ?? {})) {
+					if (typeof mineReset !== "number" || !Number.isFinite(mineReset) || mineReset <= now) {
+						continue;
+					}
+					const theirReset = record.rateLimitResetTimes?.[key];
+					if (typeof theirReset === "number" && theirReset >= mineReset) continue;
+					resets = { ...(resets ?? record.rateLimitResetTimes ?? {}), [key]: mineReset };
+				}
+				if (resets) merged.rateLimitResetTimes = resets;
+
+				if (
+					typeof mine.coolingDownUntil === "number" &&
+					mine.coolingDownUntil > now &&
+					mine.coolingDownUntil > (record.coolingDownUntil ?? 0)
+				) {
+					merged.coolingDownUntil = mine.coolingDownUntil;
+					merged.cooldownReason = mine.cooldownReason;
+				}
+
+				if (typeof mine.lastUsed === "number" && mine.lastUsed > (record.lastUsed ?? 0)) {
+					merged.lastUsed = mine.lastUsed;
+					merged.lastSwitchReason = mine.lastSwitchReason ?? record.lastSwitchReason;
+				}
+
+				return merged;
+			}),
+		};
 	}
 
 	/**
@@ -216,8 +294,17 @@ export class AccountPersistence {
 		}
 	}
 
+	/**
+	 * A disposed manager still accepts saves. `index.ts` hands the request
+	 * pipeline a manager reference and swaps the cached instance underneath it,
+	 * so an in-flight request records its 429 block on the outgoing manager
+	 * after the reload has already flushed and disposed it. Refusing the write
+	 * there would lose the block entirely — the account would be handed straight
+	 * back to rotation for another 429. `saveToDisk` routes it through
+	 * {@link mergeVolatileState} instead, which is safe to run at any time.
+	 */
 	saveToDiskDebounced(delayMs = 500): void {
-		this.ensureShutdownFlushRegistered();
+		if (!this.disposed) this.ensureShutdownFlushRegistered();
 		if (this.saveDebounceTimer) {
 			clearTimeout(this.saveDebounceTimer);
 		}
@@ -301,24 +388,28 @@ export class AccountPersistence {
 	 * replacing an `AccountManager` instance (e.g., on cache invalidation) to
 	 * avoid unbounded growth of the global cleanup queue.
 	 *
-	 * A queued debounced save is cancelled rather than flushed. Its payload is
-	 * this manager's account snapshot, and `saveToDisk` takes account membership
-	 * from that snapshot wholesale — it adopts newer credentials and longer
-	 * rate-limit blocks from disk, but never disk accounts the snapshot lacks.
-	 * A replaced manager firing 500ms later would therefore delete whatever its
-	 * successor has since loaded or added. What is dropped instead is a rotation
-	 * or `lastUsed` stamp: already last-writer-wins, and rediscovered on the
-	 * next request.
+	 * From here on this manager's account list is no longer authoritative.
+	 * `saveToDisk` takes membership from that list wholesale — it adopts newer
+	 * credentials and longer rate-limit blocks from disk, but never disk
+	 * accounts the list lacks — so a replaced manager writing it 500ms later
+	 * would delete whatever its successor has since loaded or added.
 	 *
-	 * The timer is cleared before the handler guard because the handler is
-	 * one-shot — it clears its own slot when it runs, so a manager whose
-	 * shutdown flush has already fired can still hold an armed timer.
+	 * Neither the queued timer nor an already-started save is cancelled, which
+	 * would drop real state: the only save a cancel can still reach is one
+	 * armed *after* the caller's flush, and that is the fresh rate-limit or
+	 * cooldown block an in-flight request just recorded, not a stale rotation
+	 * stamp. Both paths are marked instead, and `saveToDisk` degrades them to
+	 * {@link mergeVolatileState}: the block lands, membership stays as the
+	 * successor left it. Marking rather than cancelling is also what covers the
+	 * save that had already begun by the time this ran, which a `clearTimeout`
+	 * cannot touch at all.
+	 *
+	 * The flag is set before the handler guard because the handler is one-shot —
+	 * it clears its own slot when it runs, so a manager whose shutdown flush has
+	 * already fired must still be marked here.
 	 */
 	disposeShutdownHandler(): void {
-		if (this.saveDebounceTimer) {
-			clearTimeout(this.saveDebounceTimer);
-			this.saveDebounceTimer = null;
-		}
+		this.disposed = true;
 		if (!this.shutdownHandler) return;
 		unregisterCleanup(this.shutdownHandler);
 		this.shutdownHandler = null;

--- a/lib/accounts/persistence.ts
+++ b/lib/accounts/persistence.ts
@@ -297,11 +297,28 @@ export class AccountPersistence {
 	}
 
 	/**
-	 * Removes this manager's shutdown cleanup registration. Call this when
-	 * replacing an `AccountManager` instance (e.g., on cache invalidation)
-	 * to avoid unbounded growth of the global cleanup queue.
+	 * Tears down this manager's process-level side effects. Call this when
+	 * replacing an `AccountManager` instance (e.g., on cache invalidation) to
+	 * avoid unbounded growth of the global cleanup queue.
+	 *
+	 * A queued debounced save is cancelled rather than flushed. Its payload is
+	 * this manager's account snapshot, and `saveToDisk` takes account membership
+	 * from that snapshot wholesale — it adopts newer credentials and longer
+	 * rate-limit blocks from disk, but never disk accounts the snapshot lacks.
+	 * A replaced manager firing 500ms later would therefore delete whatever its
+	 * successor has since loaded or added. What is dropped instead is a rotation
+	 * or `lastUsed` stamp: already last-writer-wins, and rediscovered on the
+	 * next request.
+	 *
+	 * The timer is cleared before the handler guard because the handler is
+	 * one-shot — it clears its own slot when it runs, so a manager whose
+	 * shutdown flush has already fired can still hold an armed timer.
 	 */
 	disposeShutdownHandler(): void {
+		if (this.saveDebounceTimer) {
+			clearTimeout(this.saveDebounceTimer);
+			this.saveDebounceTimer = null;
+		}
 		if (!this.shutdownHandler) return;
 		unregisterCleanup(this.shutdownHandler);
 		this.shutdownHandler = null;

--- a/test/accounts-dispose-cancels-save.test.ts
+++ b/test/accounts-dispose-cancels-save.test.ts
@@ -1,13 +1,19 @@
 /**
- * `disposeShutdownHandler()` tears a manager's process-level side effects down.
- * A debounced save armed before that call is one of them: it fires up to 500ms
- * later and writes the manager's in-memory snapshot to the account file.
+ * `disposeShutdownHandler()` marks a manager as replaced. A debounced save
+ * armed before that call fires up to 500ms later; a save that had already
+ * started cannot be stopped at all.
  *
- * That snapshot is authoritative for account *membership*. `saveToDisk` adopts
- * newer credentials and longer rate-limit blocks from disk, but never adopts
- * disk accounts the snapshot lacks, so a replaced manager firing late does not
- * merely lose a rotation stamp: it deletes every account its successor has that
- * the dead one did not.
+ * The manager's snapshot is authoritative for account *membership*.
+ * `saveToDisk` adopts newer credentials and longer rate-limit blocks from disk,
+ * but never adopts disk accounts the snapshot lacks, so a replaced manager
+ * writing it late does not merely lose a rotation stamp: it deletes every
+ * account its successor has that the dead one did not.
+ *
+ * Dropping the write outright is not the answer either. The only save a
+ * cancel can still reach is one armed *after* the caller's flush, and that is
+ * the rate-limit block an in-flight request just recorded — losing it hands an
+ * exhausted account straight back to rotation. So a disposed manager still
+ * writes, with membership and credentials taken from disk.
  */
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
@@ -48,11 +54,19 @@ function managerWithForeignAccount(): AccountManager {
 	return manager;
 }
 
+/** A manager holding an account the on-disk store also has. */
+function managerSharingDiskAccount(): AccountManager {
+	const manager = new AccountManager(undefined, storageOf([ON_DISK_ACCOUNTS[0]]));
+	managers.push(manager);
+	return manager;
+}
+
+async function readStored(): Promise<AccountStorageV3> {
+	return JSON.parse(await fs.readFile(TEST_STORAGE_PATH, "utf8")) as AccountStorageV3;
+}
+
 async function storedRefreshTokens(): Promise<string[]> {
-	const raw = JSON.parse(
-		await fs.readFile(TEST_STORAGE_PATH, "utf8"),
-	) as AccountStorageV3;
-	return raw.accounts.map((account) => account.refreshToken);
+	return (await readStored()).accounts.map((account) => account.refreshToken);
 }
 
 const sleep = (ms: number): Promise<void> =>
@@ -66,14 +80,18 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-	// Dispose while the override is still active, so nothing can outlive it.
-	for (const manager of managers.splice(0)) manager.disposeShutdownHandler();
+	// Dispose and drain while the override is still active, so no write can
+	// resolve the storage path after it is cleared.
+	for (const manager of managers.splice(0)) {
+		manager.disposeShutdownHandler();
+		await manager.flushPendingSave();
+	}
 	setStoragePathDirect(null);
 	await fs.rm(TEST_STORAGE_PATH, { force: true });
 });
 
 describe("AccountManager.disposeShutdownHandler", () => {
-	it("does not write the account file after the debounce window", async () => {
+	it("keeps the store's account membership when a queued save fires after disposal", async () => {
 		// Given a store holding accounts this manager knows nothing about
 		const manager = managerWithForeignAccount();
 
@@ -98,5 +116,63 @@ describe("AccountManager.disposeShutdownHandler", () => {
 		// assertion above is about disposal rather than about a save that never
 		// had a chance to fire
 		await expect(storedRefreshTokens()).resolves.toEqual(["rt-from-a-dead-manager"]);
+	});
+
+	it("keeps membership when a save was already in flight at disposal", async () => {
+		// Given a save that has already started, so no timer cancel can reach it
+		const manager = managerWithForeignAccount();
+		const inFlight = manager.saveToDisk();
+
+		// When disposal lands before the storage transaction runs
+		manager.disposeShutdownHandler();
+		await inFlight;
+
+		// Then the store still holds exactly the accounts it started with
+		await expect(storedRefreshTokens()).resolves.toEqual([...ON_DISK_ACCOUNTS]);
+	});
+
+	it("still persists a rate-limit block recorded after the caller's flush", async () => {
+		// Given a manager that shares an account with the store, flushed clean
+		const manager = managerSharingDiskAccount();
+		await manager.flushPendingSave();
+
+		// When an in-flight request records a 429 on it and the reload disposes
+		// it before the debounce fires
+		const account = manager.getCurrentOrNextForFamilyHybrid("codex", "gpt-5.1");
+		expect(account).not.toBeNull();
+		manager.markRateLimited(account!, 60 * 60_000, "codex", "gpt-5.1");
+		manager.saveToDiskDebounced();
+		manager.disposeShutdownHandler();
+		await sleep(PAST_DEBOUNCE_MS);
+
+		// Then the block reached disk — dropping it would hand an exhausted
+		// account straight back to rotation — and membership is untouched
+		const stored = await readStored();
+		expect(stored.accounts.map((entry) => entry.refreshToken)).toEqual([...ON_DISK_ACCOUNTS]);
+		const blocked = stored.accounts.find(
+			(entry) => entry.refreshToken === ON_DISK_ACCOUNTS[0],
+		);
+		const resets = Object.values(blocked?.rateLimitResetTimes ?? {});
+		expect(resets.length).toBeGreaterThan(0);
+		expect(Math.max(...(resets as number[]))).toBeGreaterThan(Date.now());
+	});
+
+	it("leaves an unrelated account's credentials alone while doing so", async () => {
+		// Given a disposed manager whose snapshot omits two on-disk accounts
+		const manager = managerSharingDiskAccount();
+		await manager.flushPendingSave();
+		const account = manager.getCurrentOrNextForFamilyHybrid("codex", "gpt-5.1");
+		manager.markRateLimited(account!, 60 * 60_000, "codex", "gpt-5.1");
+		manager.saveToDiskDebounced();
+		manager.disposeShutdownHandler();
+		await sleep(PAST_DEBOUNCE_MS);
+
+		// Then the accounts it never held keep their own records verbatim
+		const stored = await readStored();
+		for (const refreshToken of ON_DISK_ACCOUNTS.slice(1)) {
+			const untouched = stored.accounts.find((entry) => entry.refreshToken === refreshToken);
+			expect(untouched?.rateLimitResetTimes).toBeUndefined();
+			expect(untouched?.coolingDownUntil).toBeUndefined();
+		}
 	});
 });

--- a/test/accounts-dispose-cancels-save.test.ts
+++ b/test/accounts-dispose-cancels-save.test.ts
@@ -1,0 +1,102 @@
+/**
+ * `disposeShutdownHandler()` tears a manager's process-level side effects down.
+ * A debounced save armed before that call is one of them: it fires up to 500ms
+ * later and writes the manager's in-memory snapshot to the account file.
+ *
+ * That snapshot is authoritative for account *membership*. `saveToDisk` adopts
+ * newer credentials and longer rate-limit blocks from disk, but never adopts
+ * disk accounts the snapshot lacks, so a replaced manager firing late does not
+ * merely lose a rotation stamp: it deletes every account its successor has that
+ * the dead one did not.
+ */
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { AccountManager } from "../lib/accounts.js";
+import { setStoragePathDirect, type AccountStorageV3 } from "../lib/storage.js";
+
+/** Longer than the 500ms debounce, short enough to keep the suite fast. */
+const PAST_DEBOUNCE_MS = 900;
+
+const TEST_STORAGE_PATH = join(
+	tmpdir(),
+	`oc-codex-multi-auth-dispose-cancels-save-${process.pid}-${Date.now()}.json`,
+);
+
+const ON_DISK_ACCOUNTS = ["rt-user-1", "rt-user-2", "rt-user-3"] as const;
+
+const managers: AccountManager[] = [];
+
+function storageOf(refreshTokens: readonly string[]): AccountStorageV3 {
+	return {
+		version: 3,
+		activeIndex: 0,
+		accounts: refreshTokens.map((refreshToken, index) => ({
+			refreshToken,
+			addedAt: 1_700_000_000_000,
+			lastUsed: 1_700_000_000_000 + index,
+		})),
+	};
+}
+
+/** A manager holding one account the on-disk store does not have. */
+function managerWithForeignAccount(): AccountManager {
+	const manager = new AccountManager(undefined, storageOf(["rt-from-a-dead-manager"]));
+	managers.push(manager);
+	return manager;
+}
+
+async function storedRefreshTokens(): Promise<string[]> {
+	const raw = JSON.parse(
+		await fs.readFile(TEST_STORAGE_PATH, "utf8"),
+	) as AccountStorageV3;
+	return raw.accounts.map((account) => account.refreshToken);
+}
+
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+beforeEach(async () => {
+	// Redirect account storage before any manager exists, so no save in this
+	// file can reach the developer's real account file.
+	setStoragePathDirect(TEST_STORAGE_PATH);
+	await fs.writeFile(TEST_STORAGE_PATH, JSON.stringify(storageOf(ON_DISK_ACCOUNTS)));
+});
+
+afterEach(async () => {
+	// Dispose while the override is still active, so nothing can outlive it.
+	for (const manager of managers.splice(0)) manager.disposeShutdownHandler();
+	setStoragePathDirect(null);
+	await fs.rm(TEST_STORAGE_PATH, { force: true });
+});
+
+describe("AccountManager.disposeShutdownHandler", () => {
+	it("does not write the account file after the debounce window", async () => {
+		// Given a store holding accounts this manager knows nothing about
+		const manager = managerWithForeignAccount();
+
+		// When a queued save is followed by disposal
+		manager.saveToDiskDebounced();
+		manager.disposeShutdownHandler();
+		await sleep(PAST_DEBOUNCE_MS);
+
+		// Then the store still holds exactly the accounts it started with
+		await expect(storedRefreshTokens()).resolves.toEqual([...ON_DISK_ACCOUNTS]);
+	});
+
+	it("is the only thing preventing that write", async () => {
+		// Given the same store and an identical queued save
+		const manager = managerWithForeignAccount();
+
+		// When the manager is left live instead of disposed
+		manager.saveToDiskDebounced();
+		await sleep(PAST_DEBOUNCE_MS);
+
+		// Then the save lands and replaces the store's accounts, so the
+		// assertion above is about disposal rather than about a save that never
+		// had a chance to fire
+		await expect(storedRefreshTokens()).resolves.toEqual(["rt-from-a-dead-manager"]);
+	});
+});

--- a/test/chaos/auth-invalidated-401-stress.test.ts
+++ b/test/chaos/auth-invalidated-401-stress.test.ts
@@ -22,10 +22,13 @@
  *      NOT misfire on rate-limit / entitlement / server bodies.
  */
 
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, afterAll, afterEach, beforeAll, vi } from "vitest";
 
 import { AccountManager } from "../../lib/accounts.js";
-import type { AccountStorageV3 } from "../../lib/storage.js";
+import { setStoragePathDirect, type AccountStorageV3 } from "../../lib/storage.js";
 import { ACCOUNT_LIMITS } from "../../lib/constants.js";
 import { isInvalidatedAuthTokenError } from "../../lib/request/fetch-helpers.js";
 import type { ModelFamily } from "../../lib/prompts/codex.js";
@@ -33,6 +36,15 @@ import { MODEL_FAMILIES } from "../../lib/prompts/codex.js";
 
 const FAMILY: ModelFamily = "codex";
 const COOLDOWN = ACCOUNT_LIMITS.AUTH_FAILURE_COOLDOWN_MS;
+
+// These scenarios drive the REAL AccountManager and end in
+// saveToDiskDebounced(), which without this override replaces the developer's
+// own ~/.opencode account pool with this file's fixture. Pid-scoped so
+// concurrent checkouts do not share one file.
+const TEST_STORAGE_PATH = join(
+	tmpdir(),
+	`oc-codex-multi-auth-auth-invalidated-401-${process.pid}-${Date.now()}.json`,
+);
 
 const INVALIDATED_401_BODY = {
 	error: {
@@ -133,6 +145,19 @@ function simulateRestart(manager: AccountManager): AccountManager {
 }
 
 describe("chaos/auth-invalidated-401 — real manager + real detector (issue #171)", () => {
+	beforeAll(() => {
+		setStoragePathDirect(TEST_STORAGE_PATH);
+	});
+
+	afterAll(async () => {
+		setStoragePathDirect(null);
+		try {
+			await fs.unlink(TEST_STORAGE_PATH);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+	});
+
 	afterEach(() => {
 		vi.restoreAllMocks();
 		vi.useRealTimers();

--- a/test/chaos/auth-invalidated-401-stress.test.ts
+++ b/test/chaos/auth-invalidated-401-stress.test.ts
@@ -46,6 +46,21 @@ const TEST_STORAGE_PATH = join(
 	`oc-codex-multi-auth-auth-invalidated-401-${process.pid}-${Date.now()}.json`,
 );
 
+/**
+ * Every manager this file builds, so `afterEach` can drain its debounced saves
+ * before the storage override is cleared. Redirecting the path is not enough on
+ * its own: `saveToDisk` resolves `getStoragePath()` inside the transaction, so
+ * a save still in flight when `setStoragePathDirect(null)` runs would land on
+ * the developer's real `~/.opencode` account file.
+ */
+const managers: AccountManager[] = [];
+
+function createManager(storage: AccountStorageV3): AccountManager {
+	const manager = new AccountManager(undefined, storage);
+	managers.push(manager);
+	return manager;
+}
+
 const INVALIDATED_401_BODY = {
 	error: {
 		message:
@@ -141,7 +156,7 @@ function simulateRestart(manager: AccountManager): AccountManager {
 			cooldownReason: a.cooldownReason,
 		})),
 	};
-	return new AccountManager(undefined, storage);
+	return createManager(storage);
 }
 
 describe("chaos/auth-invalidated-401 — real manager + real detector (issue #171)", () => {
@@ -158,15 +173,21 @@ describe("chaos/auth-invalidated-401 — real manager + real detector (issue #17
 		}
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		vi.restoreAllMocks();
+		// Real timers first: these cases run on fake timers, and the debounced
+		// save below never fires while the clock is frozen.
 		vi.useRealTimers();
+		for (const manager of managers.splice(0)) {
+			manager.disposeShutdownHandler();
+			await manager.flushPendingSave();
+		}
 	});
 
 	it("A: 401 on the pinned slot cools it down and rotation returns a different healthy account", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date(1_700_000_000_000));
-		const manager = new AccountManager(undefined, makeTwoAccountStorage());
+		const manager = createManager(makeTwoAccountStorage());
 
 		const dead = manager.getCurrentOrNextForFamilyHybrid(FAMILY, "gpt-5.1");
 		expect(dead).not.toBeNull();
@@ -191,7 +212,7 @@ describe("chaos/auth-invalidated-401 — real manager + real detector (issue #17
 	it("B: after success on the healthy account, persisted family routing points at it (self-heals across restart)", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date(1_700_000_000_000));
-		const manager = new AccountManager(undefined, makeTwoAccountStorage());
+		const manager = createManager(makeTwoAccountStorage());
 
 		// Family is pinned to the dead slot (index 0) initially — the #171 bug.
 		expect(manager.getActiveIndexForFamily(FAMILY)).toBe(0);
@@ -220,7 +241,7 @@ describe("chaos/auth-invalidated-401 — real manager + real detector (issue #17
 	});
 
 	it("C: clearAuthFailures on success prevents stale-count accumulation toward removal", async () => {
-		const manager = new AccountManager(undefined, makeTwoAccountStorage());
+		const manager = createManager(makeTwoAccountStorage());
 		const dead = manager.getCurrentOrNextForFamilyHybrid(FAMILY, "gpt-5.1")!;
 
 		// Two 401s (below the threshold of 3).
@@ -243,7 +264,7 @@ describe("chaos/auth-invalidated-401 — real manager + real detector (issue #17
 	});
 
 	it("D: reaching MAX_AUTH_FAILURES_BEFORE_REMOVAL removes the dead refresh-token group", async () => {
-		const manager = new AccountManager(undefined, makeTwoAccountStorage());
+		const manager = createManager(makeTwoAccountStorage());
 		const dead = manager.getCurrentOrNextForFamilyHybrid(FAMILY, "gpt-5.1")!;
 
 		let last = { removed: 0, cooledCount: 0, failures: 0 };
@@ -264,7 +285,7 @@ describe("chaos/auth-invalidated-401 — real manager + real detector (issue #17
 	it("E: single standalone account 401 exercises the cooledCount fallback and cools the lone account", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date(1_700_000_000_000));
-		const manager = new AccountManager(undefined, makeSingleAccountStorage());
+		const manager = createManager(makeSingleAccountStorage());
 		const solo = manager.getCurrentOrNextForFamilyHybrid(FAMILY, "gpt-5.1")!;
 		expect(solo.refreshToken).toBe("rt-solo");
 
@@ -293,7 +314,7 @@ describe("chaos/auth-invalidated-401 — real manager + real detector (issue #17
 	it("E2: explicit fallback — markAccountCoolingDown fires when no token group matches", () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date(1_700_000_000_000));
-		const manager = new AccountManager(undefined, makeSingleAccountStorage());
+		const manager = createManager(makeSingleAccountStorage());
 		const solo = manager.getCurrentOrNextForFamilyHybrid(FAMILY, "gpt-5.1")!;
 
 		// Simulate the cooledCount<=0 branch directly: a token with no live match.


### PR DESCRIPTION
## Summary

- What changed?
  - `disposeShutdownHandler()` now clears the pending debounce timer as well as unregistering the shutdown flush. It previously did only the latter, so a manager that had been disposed still fired its queued `saveToDisk()` up to 500ms later.
  - `test/chaos/auth-invalidated-401-stress.test.ts` points account storage at a pid-scoped temp file for the duration of the suite, the way `rotation-integration.test.ts` and `chaos/storage-faults.test.ts` already do.
- Why is this needed?
  - Running `npm test` could overwrite the contributor's own `~/.opencode/oc-codex-multi-auth-accounts.json` with a test fixture, deleting real accounts and their refresh tokens. I hit this: a six-account pool was replaced by the two-account fixture from the 401 stress suite.
  - The write is destructive rather than merely stale because `saveToDisk` takes account *membership* from the in-memory snapshot wholesale. It adopts newer credentials and longer rate-limit blocks from disk, but it never adopts disk accounts the snapshot lacks. A disposed manager firing late therefore deletes every account its successor has loaded or added since.
  - The same shape can occur in production wherever an `AccountManager` is replaced while a save is queued: the outgoing instance's snapshot lands on top of its successor's. Cancelling on dispose drops a rotation or `lastUsed` stamp instead, which is already last-writer-wins and is rediscovered on the next request.

The two commits are independent layers. The first stops a disposed manager from writing at all. The second does not depend on a manager being disposed in time, so any future scenario in that suite writes to the temp file rather than to a real account pool.

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`
- [ ] Not applicable

Additional verification:

- Reproduced first: with a stand-in account file holding six accounts, the pre-fix code replaced them with the two fixture entries.
- The regression test in the first commit fails on unmodified code with `expected [ 'rt-from-a-dead-manager' ] to deeply equal [ 'rt-user-1', 'rt-user-2', … ]` and passes with the fix. Its second case leaves the manager live and asserts the write *does* land, so the first case cannot pass vacuously.
- The storage override was verified on its own by reverting the production fix and re-running the 401 stress suite against the stand-in file: all six accounts survived.
- A full `npm test` against a real home directory left the account file byte-identical, same mtime and same md5, before and after.
- One pre-existing failure remains on `main`: `chaos/auth-faults.test.ts` scenario 6 asserts it is the first binder of port 1455 and fails when it runs beside `oauth-server.integration.test.ts` under file parallelism. Both files pass when run alone, and this change touches no port-binding code.

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue: none.
- Follow-up work or rollout notes:
  - The docstring on `simulateRestart` in the 401 stress suite claimed the scenarios ran "without touching the real ~/.opencode file". That was true of `simulateRestart` itself and untrue of the handler the scenarios replay, which ends in `saveToDiskDebounced()`.
  - The port-1455 collision noted above is unrelated to this change and is addressed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Account data saves now complete safely when an account manager is replaced or disposed.
  - Recent rate-limit blocks, cooldowns, and usage timestamps are preserved without overwriting credentials or other account records.
  - Disposed managers can continue processing pending debounced saves reliably.

- **Tests**
  - Expanded coverage for in-flight saves, post-save rate-limit persistence, account record preservation, and restart scenarios.
  - Test storage is isolated and cleaned up safely to prevent changes to local account data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr narrows writes from disposed managers to volatile state and redirects the 401 stress suite to temporary storage.
- preserves current account membership and credentials during late concurrent saves
- adds vitest coverage for queued and in-flight disposed-manager saves
- tracks and drains stress-suite managers before restoring storage

<h3>Confidence Score: 3/5</h3>

the pr is not safe to merge until teardown guarantees every manager is disposed and drained even when an earlier flush fails.

a windows filesystem or storage-contention failure can reject one flush, abort cleanup of later managers, and let a pending fixture save reach the developer's real account and refresh-token store after path restoration.

**Files Needing Attention:** test/chaos/auth-invalidated-401-stress.test.ts

<details open><summary><h3>Security Review</h3></summary>

the teardown remains unsafe when one manager flush rejects: later managers retain live timers, so restoring the default path can expose the real token store, including under windows filesystem contention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/accounts/persistence.ts | disposed saves now preserve disk membership and credentials while merging later volatile routing state. |
| test/accounts-dispose-cancels-save.test.ts | adds vitest coverage for queued and in-flight saves after manager disposal. |
| test/chaos/auth-invalidated-401-stress.test.ts | temp-path isolation is improved, but one rejected flush aborts cleanup and leaves a token-safety race before path restoration. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/chaos/auth-invalidated-401-stress.test.ts:181-184
**flush failure aborts teardown**

when one `flushPendingSave()` rejects, this loop exits before disposing and draining later managers. their real-timer saves can then run after `afterAll` restores the default path, overwriting the developer's real account pool and refresh tokens; windows filesystem contention makes this token-safety path reachable. **how this was verified:** `flushPendingSave()` propagates persistence failures, so one rejection prevents the loop from reaching managers with pending saves.

```suggestion
		let cleanupError: unknown;
		for (const manager of managers.splice(0)) {
			manager.disposeShutdownHandler();
			try {
				await manager.flushPendingSave();
			} catch (error) {
				cleanupError ??= error;
			}
		}
		if (cleanupError) throw cleanupError;
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(accounts): downgrade a disposed mana..."](https://github.com/ndycode/oc-codex-multi-auth/commit/4a08b6468e559559f2b10f7079f4db14cdb2919e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59340601)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Multi-account management](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/account-management.md)
- Knowledge Base — [Account state and secure storage](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/account-state-and-storage.md)

<!-- /greptile_comment -->