### PR TITLE
feat(auth): name accounts by ChatGPT identity and report the plan tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ Most of these also run as a **direct CLI** with no agent/model involvement (no t
 - unsupported-model handling is strict by default, with opt-in fallback controls
 - TUI quota status follows the account/workspace used by the latest request
 - Business workspace memberships and Personal accounts keep separate usage and quota windows. Business members sharing one workspace are distinguished by their member/seat identity, so their usage is not collapsed into one row.
-- An account is labeled `<email> id:<last 6 of account id>` from its own ChatGPT credential. The OAuth id_token also lists the API-platform organizations the login belongs to; those are not ChatGPT workspaces and are never used to name an account. A label you set with `codex-label` is always kept.
-- The ChatGPT plan (`Free`, `Plus`, `Pro`, `Business`, `Business Premium`) is read from the access token and shown by `codex-list` and `codex-status`. An unrecognized plan is reported verbatim rather than renamed.
+- An account identifies itself by its own ChatGPT email and the last 6 characters of its account id, with the email masked when `maskEmail` is on. The OAuth id_token also lists the API-platform organizations the login belongs to; those are not ChatGPT workspaces and are never used to name an account, so logging in clears a label left behind by one. A label you set with `codex-label` is always kept.
+- The ChatGPT plan (`Free`, `Plus`, `Pro`, `Business`, `Business Premium`) is read from the access token, refreshed on every token refresh, and shown by `codex-list` and `codex-status`. `codex-limits` and the TUI read the plan live from the usage endpoint and name it the same way. An unrecognized plan is reported verbatim rather than renamed.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ Most of these also run as a **direct CLI** with no agent/model involvement (no t
 - unsupported-model handling is strict by default, with opt-in fallback controls
 - TUI quota status follows the account/workspace used by the latest request
 - Business workspace memberships and Personal accounts keep separate usage and quota windows. Business members sharing one workspace are distinguished by their member/seat identity, so their usage is not collapsed into one row.
+- An account is labeled `<email> id:<last 6 of account id>` from its own ChatGPT credential. The OAuth id_token also lists the API-platform organizations the login belongs to; those are not ChatGPT workspaces and are never used to name an account. A label you set with `codex-label` is always kept.
+- The ChatGPT plan (`Free`, `Plus`, `Pro`, `Business`, `Business Premium`) is read from the access token and shown by `codex-list` and `codex-status`. An unrecognized plan is reported verbatim rather than renamed.
 
 ---
 

--- a/index.ts
+++ b/index.ts
@@ -35,6 +35,7 @@ import {
         parseAuthorizationInput,
         REDIRECT_URI,
 } from "./lib/auth/auth.js";
+import { formatPlanType } from "./lib/auth/plan-tier.js";
 import {
 	buildDeviceCodeInstructions,
 	completeDeviceCodeSession,
@@ -3546,7 +3547,8 @@ export const OpenAIOAuthPlugin: Plugin = async ({ client }: PluginInput) => {
 										parts.push(`${limit.name} ${formatUsageLimitSummary(limit.window)}`);
 									}
 								}
-								if (usage.planType) parts.push(`plan:${usage.planType}`);
+								const planLabel = formatPlanType(usage.planType);
+								if (planLabel) parts.push(`plan:${planLabel}`);
 								if (usage.credits) parts.push(`credits:${usage.credits}`);
 								return parts.length > 0 ? parts.join(", ") : "quota unavailable";
 							};

--- a/lib/accounts.ts
+++ b/lib/accounts.ts
@@ -39,7 +39,6 @@ export {
 	extractAccountId,
 	extractAccountEmail,
 	getAccountIdCandidates,
-	relabelCandidateForAccountId,
 	selectBestAccountCandidate,
 	shouldUpdateAccountIdFromToken,
 	resolveRequestAccountId,

--- a/lib/accounts/persistence.ts
+++ b/lib/accounts/persistence.ts
@@ -297,11 +297,28 @@ export class AccountPersistence {
 	}
 
 	/**
-	 * Removes this manager's shutdown cleanup registration. Call this when
-	 * replacing an `AccountManager` instance (e.g., on cache invalidation)
-	 * to avoid unbounded growth of the global cleanup queue.
+	 * Tears down this manager's process-level side effects. Call this when
+	 * replacing an `AccountManager` instance (e.g., on cache invalidation) to
+	 * avoid unbounded growth of the global cleanup queue.
+	 *
+	 * A queued debounced save is cancelled rather than flushed. Its payload is
+	 * this manager's account snapshot, and `saveToDisk` takes account membership
+	 * from that snapshot wholesale — it adopts newer credentials and longer
+	 * rate-limit blocks from disk, but never disk accounts the snapshot lacks.
+	 * A replaced manager firing 500ms later would therefore delete whatever its
+	 * successor has since loaded or added. What is dropped instead is a rotation
+	 * or `lastUsed` stamp: already last-writer-wins, and rediscovered on the
+	 * next request.
+	 *
+	 * The timer is cleared before the handler guard because the handler is
+	 * one-shot — it clears its own slot when it runs, so a manager whose
+	 * shutdown flush has already fired can still hold an armed timer.
 	 */
 	disposeShutdownHandler(): void {
+		if (this.saveDebounceTimer) {
+			clearTimeout(this.saveDebounceTimer);
+			this.saveDebounceTimer = null;
+		}
 		if (!this.shutdownHandler) return;
 		unregisterCleanup(this.shutdownHandler);
 		this.shutdownHandler = null;

--- a/lib/accounts/persistence.ts
+++ b/lib/accounts/persistence.ts
@@ -32,6 +32,12 @@ export class AccountPersistence {
 	private saveDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private pendingSave: Promise<void> | null = null;
 	private shutdownHandler: (() => Promise<void>) | null = null;
+	/**
+	 * Set by {@link disposeShutdownHandler}. From that point this manager has
+	 * been replaced, so its account list is no longer authoritative and every
+	 * further write degrades to {@link mergeVolatileState}.
+	 */
+	private disposed = false;
 
 	constructor(private readonly state: AccountState) {}
 
@@ -87,6 +93,17 @@ export class AccountPersistence {
 		// account permanently. Adopt any newer on-disk credentials before
 		// persisting.
 		await withAccountStorageTransaction(async (current, persist) => {
+			if (this.disposed) {
+				// Disposal landed while this save was already in flight — after
+				// the timer had fired, so cancelling the timer could not stop it.
+				// Its account list belongs to a manager that has been replaced,
+				// so persisting it wholesale would delete whatever the successor
+				// has since loaded or added. Degrade to the volatile merge, which
+				// keeps the rate-limit and cooldown state this snapshot carries
+				// without touching membership.
+				if (current) await persist(this.mergeVolatileState(current));
+				return;
+			}
 			if (current) {
 				// Before adoptNewerDiskCredentials: for records without workspace
 				// ids the refresh token participates in the identity key, and
@@ -97,6 +114,67 @@ export class AccountPersistence {
 			}
 			await persist(storage);
 		});
+	}
+
+	/**
+	 * Persist only the volatile rotation state this manager holds: rate-limit
+	 * blocks, cooldowns, and last-used stamps, each resolved to whichever side
+	 * runs longer or later.
+	 *
+	 * Account membership, credentials, and the active-index routing are taken
+	 * from `disk` untouched. That is what makes the write safe for a manager
+	 * that has already been replaced: a 429 recorded on it still reaches disk,
+	 * and it cannot delete an account its successor loaded or added.
+	 *
+	 * Live in-memory state is left alone for the same reason
+	 * {@link adoptLongerDiskRateLimits} leaves it alone: a missing block is
+	 * self-correcting from the next response's quota headers.
+	 */
+	private mergeVolatileState(disk: AccountStorageV3): AccountStorageV3 {
+		const now = nowMs();
+		const mineByIdentity = new Map<string, AccountState["accounts"][number]>();
+		for (const account of this.state.accounts) {
+			mineByIdentity.set(getWorkspaceIdentityKey(account), account);
+		}
+
+		return {
+			...disk,
+			accounts: disk.accounts.map((record) => {
+				const mine = mineByIdentity.get(getWorkspaceIdentityKey(record));
+				if (!mine) return record;
+				const merged: AccountMetadataV3 = { ...record };
+
+				// Longest-block-wins per quota key, matching adoptLongerDiskRateLimits.
+				// Only blocks still in the future are carried, so an entry this
+				// manager never pruned cannot resurrect an expired block.
+				let resets: Record<string, number | undefined> | undefined;
+				for (const [key, mineReset] of Object.entries(mine.rateLimitResetTimes ?? {})) {
+					if (typeof mineReset !== "number" || !Number.isFinite(mineReset) || mineReset <= now) {
+						continue;
+					}
+					const theirReset = record.rateLimitResetTimes?.[key];
+					if (typeof theirReset === "number" && theirReset >= mineReset) continue;
+					resets = { ...(resets ?? record.rateLimitResetTimes ?? {}), [key]: mineReset };
+				}
+				if (resets) merged.rateLimitResetTimes = resets;
+
+				if (
+					typeof mine.coolingDownUntil === "number" &&
+					mine.coolingDownUntil > now &&
+					mine.coolingDownUntil > (record.coolingDownUntil ?? 0)
+				) {
+					merged.coolingDownUntil = mine.coolingDownUntil;
+					merged.cooldownReason = mine.cooldownReason;
+				}
+
+				if (typeof mine.lastUsed === "number" && mine.lastUsed > (record.lastUsed ?? 0)) {
+					merged.lastUsed = mine.lastUsed;
+					merged.lastSwitchReason = mine.lastSwitchReason ?? record.lastSwitchReason;
+				}
+
+				return merged;
+			}),
+		};
 	}
 
 	/**
@@ -217,8 +295,17 @@ export class AccountPersistence {
 		}
 	}
 
+	/**
+	 * A disposed manager still accepts saves. `index.ts` hands the request
+	 * pipeline a manager reference and swaps the cached instance underneath it,
+	 * so an in-flight request records its 429 block on the outgoing manager
+	 * after the reload has already flushed and disposed it. Refusing the write
+	 * there would lose the block entirely — the account would be handed straight
+	 * back to rotation for another 429. `saveToDisk` routes it through
+	 * {@link mergeVolatileState} instead, which is safe to run at any time.
+	 */
 	saveToDiskDebounced(delayMs = 500): void {
-		this.ensureShutdownFlushRegistered();
+		if (!this.disposed) this.ensureShutdownFlushRegistered();
 		if (this.saveDebounceTimer) {
 			clearTimeout(this.saveDebounceTimer);
 		}
@@ -302,24 +389,28 @@ export class AccountPersistence {
 	 * replacing an `AccountManager` instance (e.g., on cache invalidation) to
 	 * avoid unbounded growth of the global cleanup queue.
 	 *
-	 * A queued debounced save is cancelled rather than flushed. Its payload is
-	 * this manager's account snapshot, and `saveToDisk` takes account membership
-	 * from that snapshot wholesale — it adopts newer credentials and longer
-	 * rate-limit blocks from disk, but never disk accounts the snapshot lacks.
-	 * A replaced manager firing 500ms later would therefore delete whatever its
-	 * successor has since loaded or added. What is dropped instead is a rotation
-	 * or `lastUsed` stamp: already last-writer-wins, and rediscovered on the
-	 * next request.
+	 * From here on this manager's account list is no longer authoritative.
+	 * `saveToDisk` takes membership from that list wholesale — it adopts newer
+	 * credentials and longer rate-limit blocks from disk, but never disk
+	 * accounts the list lacks — so a replaced manager writing it 500ms later
+	 * would delete whatever its successor has since loaded or added.
 	 *
-	 * The timer is cleared before the handler guard because the handler is
-	 * one-shot — it clears its own slot when it runs, so a manager whose
-	 * shutdown flush has already fired can still hold an armed timer.
+	 * Neither the queued timer nor an already-started save is cancelled, which
+	 * would drop real state: the only save a cancel can still reach is one
+	 * armed *after* the caller's flush, and that is the fresh rate-limit or
+	 * cooldown block an in-flight request just recorded, not a stale rotation
+	 * stamp. Both paths are marked instead, and `saveToDisk` degrades them to
+	 * {@link mergeVolatileState}: the block lands, membership stays as the
+	 * successor left it. Marking rather than cancelling is also what covers the
+	 * save that had already begun by the time this ran, which a `clearTimeout`
+	 * cannot touch at all.
+	 *
+	 * The flag is set before the handler guard because the handler is one-shot —
+	 * it clears its own slot when it runs, so a manager whose shutdown flush has
+	 * already fired must still be marked here.
 	 */
 	disposeShutdownHandler(): void {
-		if (this.saveDebounceTimer) {
-			clearTimeout(this.saveDebounceTimer);
-			this.saveDebounceTimer = null;
-		}
+		this.disposed = true;
 		if (!this.shutdownHandler) return;
 		unregisterCleanup(this.shutdownHandler);
 		this.shutdownHandler = null;

--- a/lib/accounts/persistence.ts
+++ b/lib/accounts/persistence.ts
@@ -52,6 +52,7 @@ export class AccountPersistence {
 				organizationId: account.organizationId,
 				accountIdSource: account.accountIdSource,
 				accountLabel: account.accountLabel,
+				planType: account.planType,
 				accountTags: account.accountTags,
 				accountNote: account.accountNote,
 				email: account.email,

--- a/lib/accounts/state.ts
+++ b/lib/accounts/state.ts
@@ -37,6 +37,7 @@ export interface ManagedAccount {
 	organizationId?: string;
 	accountIdSource?: AccountIdSource;
 	accountLabel?: string;
+	planType?: string;
 	accountTags?: string[];
 	accountNote?: string;
 	email?: string;
@@ -354,6 +355,7 @@ export class AccountState {
 						organizationId: account.organizationId,
 						accountIdSource: account.accountIdSource,
 						accountLabel: account.accountLabel,
+						planType: account.planType,
 						accountTags: account.accountTags,
 						accountNote: missingOAuthScopes.length > 0
 							? appendReauthNote(account.accountNote, missingOAuthScopes)

--- a/lib/accounts/state.ts
+++ b/lib/accounts/state.ts
@@ -25,6 +25,7 @@ import {
 	sanitizeEmail,
 	shouldUpdateAccountIdFromToken,
 } from "../auth/token-utils.js";
+import { extractPlanType } from "../auth/plan-tier.js";
 import { getMissingRequiredOAuthScopes, normalizeScope } from "../auth/scopes.js";
 import { getHealthTracker, getTokenTracker } from "../rotation.js";
 import { remapRateLimitBackoffAfterRemoval } from "../request/rate-limit-backoff.js";
@@ -636,6 +637,15 @@ export class AccountState {
 		const scope = getAuthScope(auth);
 		if (scope) {
 			account.oauthScope = scope;
+		}
+		// Re-read from the token that just arrived. Reading it only at login
+		// would pin the tier a Plus -> Pro upgrade left behind until the user
+		// re-authenticated, while the live `x-codex-plan-type` header already
+		// reported the new one. A token that carries no claim leaves the stored
+		// value alone rather than erasing it.
+		const planType = extractPlanType(auth.access);
+		if (planType) {
+			account.planType = planType;
 		}
 		if (previousRefreshToken !== account.refreshToken) {
 			// Stamp the rotation so a concurrent process persisting a stale

--- a/lib/auth/login-runner.ts
+++ b/lib/auth/login-runner.ts
@@ -11,8 +11,10 @@ import {
 // re-export it.
 import {
 	extractAccountUserId,
-	relabelCandidateForAccountId,
+	formatChatGptAccountLabel,
+	isGeneratedAccountLabel,
 } from "./token-utils.js";
+import { extractPlanType } from "./plan-tier.js";
 import { logInfo } from "../logger.js";
 import { normalizeScope } from "./scopes.js";
 import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
@@ -37,6 +39,7 @@ type MergeableAccountRecord = {
 	organizationId?: string;
 	accountIdSource?: AccountIdSource;
 	accountLabel?: string;
+	planType?: string;
 	email?: string;
 	lastSwitchReason?: string;
 	rateLimitResetTimes?: Record<string, number | undefined>;
@@ -133,6 +136,8 @@ export function mergeStoredAccountPair<T extends MergeableAccountRecord>(
 		accessToken: newer.accessToken ?? older.accessToken,
 		expiresAt: newer.expiresAt ?? older.expiresAt,
 		oauthScope: newer.oauthScope ?? older.oauthScope,
+		// Follows the access token it was read from, so an upgrade is not pinned stale.
+		planType: newer.planType ?? older.planType,
 		// Follows the token fields: the rotation stamp must describe the
 		// refreshToken that actually survived the merge. No fallback to the
 		// older stamp when the newer token wins — attaching an old timestamp
@@ -159,6 +164,7 @@ export type TokenSuccessWithAccount = TokenSuccess & {
 	organizationIdOverride?: string;
 	accountIdSource?: AccountIdSource;
 	accountLabel?: string;
+	planType?: string;
 };
 
 export type AccountSelectionResult = {
@@ -186,6 +192,7 @@ const createSelectionVariant = (
 		organizationId?: string;
 		source?: AccountIdSource;
 		label?: string;
+		planType?: string;
 	},
 ): TokenSuccessWithAccount => ({
 	...tokens,
@@ -193,9 +200,11 @@ const createSelectionVariant = (
 	organizationIdOverride: candidate.organizationId,
 	accountIdSource: candidate.source,
 	accountLabel: candidate.label,
+	planType: candidate.planType,
 });
 
 export function resolveAccountSelection(tokens: TokenSuccess): AccountSelectionResult {
+	const planType = extractPlanType(tokens.access);
 	const override = (process.env.CODEX_AUTH_ACCOUNT_ID ?? "").trim();
 	if (override) {
 		const suffix = override.length > 6 ? override.slice(-6) : override;
@@ -205,6 +214,7 @@ export function resolveAccountSelection(tokens: TokenSuccess): AccountSelectionR
 			accountIdOverride: override,
 			accountIdSource: "manual" as const,
 			accountLabel: `Override [id:${suffix}]`,
+			planType,
 		};
 		return {
 			primary,
@@ -214,17 +224,19 @@ export function resolveAccountSelection(tokens: TokenSuccess): AccountSelectionR
 
 	const candidates = getAccountIdCandidates(tokens.access, tokens.idToken);
 	if (candidates.length === 0) {
+		const primary = { ...tokens, planType };
 		return {
-			primary: tokens,
-			variantsForPersistence: [tokens],
+			primary,
+			variantsForPersistence: [primary],
 		};
 	}
 
 	const choice = selectBestAccountCandidate(candidates);
 	if (!choice) {
+		const primary = { ...tokens, planType };
 		return {
-			primary: tokens,
-			variantsForPersistence: [tokens],
+			primary,
+			variantsForPersistence: [primary],
 		};
 	}
 
@@ -242,9 +254,17 @@ export function resolveAccountSelection(tokens: TokenSuccess): AccountSelectionR
 	// `chatgpt_account_id` claim, so per-entry tokens are what give per-entry
 	// quotas: bind to the token-scoped id and let a second `auth login` under
 	// the other workspace append a separate account carrying its own token.
-	// The chosen workspace's name and organization id ride along as metadata -
+	// The chosen workspace's organization id rides along as metadata -
 	// `organizationId` is display/dedupe-only and is not sent as a header unless
 	// CODEX_AUTH_SEND_ORGANIZATION_HEADER=1 (see lib/request/fetch-helpers.ts).
+	//
+	// The candidate's *name* is deliberately not used as the label. With
+	// `id_token_add_organizations=true` those candidates enumerate the user's
+	// API-platform organizations, not their ChatGPT workspaces, so naming an
+	// account after one reported an unrelated org ("<api org> (role:owner)")
+	// for a personal ChatGPT subscription. A ChatGPT credential carries no
+	// workspace name at all, so the label is built from the identity it does
+	// carry: the account email and the routing account id.
 	const routingCandidate =
 		candidates.find((candidate) => candidate.source === "token") ??
 		candidates.find((candidate) => candidate.source === "id_token") ??
@@ -253,10 +273,11 @@ export function resolveAccountSelection(tokens: TokenSuccess): AccountSelectionR
 		accountId: routingCandidate.accountId,
 		organizationId: choice.organizationId,
 		source: routingCandidate.source ?? "token",
-		label:
-			routingCandidate === choice
-				? choice.label
-				: relabelCandidateForAccountId(choice.label, routingCandidate.accountId),
+		label: formatChatGptAccountLabel(
+			sanitizeEmail(extractAccountEmail(tokens.access, tokens.idToken)),
+			routingCandidate.accountId,
+		),
+		planType,
 	});
 
 	return {
@@ -686,6 +707,7 @@ export async function persistAccountPool(
 						(result.accountIdOverride ? "manual" : "token")
 					: undefined;
 			const accountLabel = result.accountLabel;
+			const planType = result.planType ?? extractPlanType(result.access);
 			const accountEmail = sanitizeEmail(extractAccountEmail(result.access, result.idToken));
 			// A blank scope must never reach storage: it is indistinguishable from
 			// "granted nothing" at load time, and `?? existing.oauthScope` below
@@ -777,6 +799,7 @@ export async function persistAccountPool(
 					organizationId,
 					accountIdSource,
 					accountLabel,
+					planType,
 					email: accountEmail,
 					refreshToken: result.refresh,
 					accessToken: result.access,
@@ -807,9 +830,12 @@ export async function persistAccountPool(
 				: normalizedAccountId
 					? accountIdSource ?? existing.accountIdSource
 					: existing.accountIdSource;
-			const nextAccountLabel = preserveOrgIdentity
-				? existing.accountLabel ?? accountLabel
-				: accountLabel ?? existing.accountLabel;
+			// A label someone chose is theirs to keep. Only a generated one is
+			// refreshed, so re-logging in replaces a stale label that named an
+			// API organization without overwriting a name a user typed.
+			const nextAccountLabel = isGeneratedAccountLabel(existing.accountLabel)
+				? accountLabel ?? existing.accountLabel
+				: existing.accountLabel;
 			accounts[existingIndex] = {
 				...existing,
 				accountId: nextAccountId,
@@ -817,6 +843,7 @@ export async function persistAccountPool(
 				organizationId: nextOrganizationId,
 				accountIdSource: nextAccountIdSource,
 				accountLabel: nextAccountLabel,
+				planType: planType ?? existing.planType,
 				email: nextEmail,
 				refreshToken: result.refresh,
 				accessToken: result.access,

--- a/lib/auth/login-runner.ts
+++ b/lib/auth/login-runner.ts
@@ -11,7 +11,6 @@ import {
 // re-export it.
 import {
 	extractAccountUserId,
-	formatChatGptAccountLabel,
 	isGeneratedAccountLabel,
 } from "./token-utils.js";
 import { extractPlanType } from "./plan-tier.js";
@@ -262,9 +261,17 @@ export function resolveAccountSelection(tokens: TokenSuccess): AccountSelectionR
 	// `id_token_add_organizations=true` those candidates enumerate the user's
 	// API-platform organizations, not their ChatGPT workspaces, so naming an
 	// account after one reported an unrelated org ("<api org> (role:owner)")
-	// for a personal ChatGPT subscription. A ChatGPT credential carries no
-	// workspace name at all, so the label is built from the identity it does
-	// carry: the account email and the routing account id.
+	// for a personal ChatGPT subscription.
+	//
+	// No label is generated in its place either. A ChatGPT credential carries
+	// no workspace name at all, only `chatgpt_account_id` and the account
+	// email — and every display surface already renders both, the email
+	// through `resolveDisplayEmail` so `maskEmail` applies. Restating them in
+	// the label would print each identity twice and, because the label is
+	// rendered verbatim, would put the unmasked address back on screen. The
+	// login clears the stale org-derived label instead (see
+	// `persistAccountPool`) and the account identifies itself as
+	// "<email>, id:<suffix>".
 	const routingCandidate =
 		candidates.find((candidate) => candidate.source === "token") ??
 		candidates.find((candidate) => candidate.source === "id_token") ??
@@ -273,10 +280,6 @@ export function resolveAccountSelection(tokens: TokenSuccess): AccountSelectionR
 		accountId: routingCandidate.accountId,
 		organizationId: choice.organizationId,
 		source: routingCandidate.source ?? "token",
-		label: formatChatGptAccountLabel(
-			sanitizeEmail(extractAccountEmail(tokens.access, tokens.idToken)),
-			routingCandidate.accountId,
-		),
 		planType,
 	});
 
@@ -831,10 +834,14 @@ export async function persistAccountPool(
 					? accountIdSource ?? existing.accountIdSource
 					: existing.accountIdSource;
 			// A label someone chose is theirs to keep. Only a generated one is
-			// refreshed, so re-logging in replaces a stale label that named an
-			// API organization without overwriting a name a user typed.
+			// replaced, so re-logging in drops a stale label that named an API
+			// organization without overwriting a name a user typed.
+			//
+			// No `?? existing.accountLabel` fallback: the ChatGPT path now
+			// produces no label at all, and falling back would pin exactly the
+			// wrong org-derived label this is meant to clear.
 			const nextAccountLabel = isGeneratedAccountLabel(existing.accountLabel)
-				? accountLabel ?? existing.accountLabel
+				? accountLabel
 				: existing.accountLabel;
 			accounts[existingIndex] = {
 				...existing,

--- a/lib/auth/plan-tier.ts
+++ b/lib/auth/plan-tier.ts
@@ -1,0 +1,47 @@
+/**
+ * ChatGPT subscription tier, read from the OAuth access token.
+ *
+ * The `chatgpt_plan_type` claim is the only plan signal the credential itself
+ * carries. It agrees with the `plan_type` field the Codex `/wham/usage`
+ * endpoint returns for the same account, so the tier is available without a
+ * network round trip and stays correct while offline.
+ */
+
+import { decodeJWT } from "./auth.js";
+import { JWT_CLAIM_PATH } from "../constants.js";
+
+/**
+ * `chatgpt_plan_type` slug to the subscription name OpenAI shows for it.
+ *
+ * `team` is the slug still emitted for what OpenAI now calls Business, and
+ * `self_serve_business_prolite` is the premium Business seat - neither name is
+ * derivable from its slug, so both are pinned here rather than reformatted.
+ */
+const PLAN_TYPE_LABELS: ReadonlyMap<string, string> = new Map([
+	["free", "Free"],
+	["plus", "Plus"],
+	["pro", "Pro"],
+	["team", "Business"],
+	["business", "Business"],
+	["self_serve_business_prolite", "Business Premium"],
+	["enterprise", "Enterprise"],
+]);
+
+export function extractPlanType(accessToken?: string): string | undefined {
+	if (!accessToken) return undefined;
+	const planType = decodeJWT(accessToken)?.[JWT_CLAIM_PATH]?.chatgpt_plan_type;
+	if (typeof planType !== "string") return undefined;
+	const normalized = planType.trim().toLowerCase();
+	return normalized ? normalized : undefined;
+}
+
+/**
+ * An unrecognized slug is returned verbatim: a plan we cannot name is still
+ * worth showing, and inventing a name for it would misreport the subscription.
+ */
+export function formatPlanType(planType: string | undefined): string | undefined {
+	if (!planType) return undefined;
+	const normalized = planType.trim().toLowerCase();
+	if (!normalized) return undefined;
+	return PLAN_TYPE_LABELS.get(normalized) ?? planType.trim();
+}

--- a/lib/auth/plan-tier.ts
+++ b/lib/auth/plan-tier.ts
@@ -38,8 +38,13 @@ export function extractPlanType(accessToken?: string): string | undefined {
 /**
  * An unrecognized slug is returned verbatim: a plan we cannot name is still
  * worth showing, and inventing a name for it would misreport the subscription.
+ *
+ * Accepts `null` so the live `/wham/usage` and `x-codex-plan-type` readings —
+ * which type their absent plan as `null`, not `undefined` — go through the same
+ * naming as the copy stored at login. Without that, one seat printed "Business"
+ * in `codex-list` and `team` in `codex-limits` and the TUI.
  */
-export function formatPlanType(planType: string | undefined): string | undefined {
+export function formatPlanType(planType: string | null | undefined): string | undefined {
 	if (!planType) return undefined;
 	const normalized = planType.trim().toLowerCase();
 	if (!normalized) return undefined;

--- a/lib/auth/token-utils.ts
+++ b/lib/auth/token-utils.ts
@@ -60,34 +60,21 @@ function formatTokenCandidateLabel(prefix: string, accountId: string): string {
 }
 
 /**
- * Trailing `[id:…]` marks a label this plugin generated. A user-supplied label
- * never carries one, which is what lets a login refresh a stale generated
- * label without overwriting a name someone chose.
+ * Trailing `[id:…]` marks a label this plugin generated — the shape every
+ * generator here emits, via {@link formatTokenCandidateLabel} or the `Override
+ * [id:…]` branch in `resolveAccountSelection`. A user-supplied label never
+ * carries one, which is what lets a login clear a stale generated label
+ * without overwriting a name someone chose with `codex-label`.
  */
 const GENERATED_LABEL_PATTERN = /\s\[id:[^\]]*\]$/;
 
 /**
- * The account label for a ChatGPT-backed credential.
+ * Whether a stored label may be replaced by a login.
  *
- * A ChatGPT OAuth token names no workspace: it carries `chatgpt_account_id`
- * (the workspace) and `chatgpt_account_user_id` (the seat), and nothing else
- * that identifies either. Email plus the account id suffix is therefore the
- * most identifying label the credential supports, and it keeps two seats of
- * one Business workspace distinguishable.
+ * A blank label counts as generated so an account that never had one can pick
+ * one up. Anything that does not carry the `[id:…]` marker is treated as a
+ * name a user chose and is left alone.
  */
-export function formatChatGptAccountLabel(
-	email: string | undefined,
-	accountId: string | undefined,
-): string | undefined {
-	const normalizedEmail = toStringValue(email);
-	const normalizedAccountId = toStringValue(accountId);
-	if (normalizedAccountId) {
-		const suffix = `id:${formatAccountIdSuffix(normalizedAccountId)}`;
-		return normalizedEmail ? `${normalizedEmail} ${suffix}` : suffix;
-	}
-	return normalizedEmail;
-}
-
 export function isGeneratedAccountLabel(label: string | undefined): boolean {
 	const normalized = toStringValue(label);
 	if (!normalized) return true;

--- a/lib/auth/token-utils.ts
+++ b/lib/auth/token-utils.ts
@@ -4,7 +4,7 @@
  */
 
 import { decodeJWT } from "./auth.js";
-import { JWT_CLAIM_PATH } from "../constants.js";
+import { JWT_CLAIM_PATH, JWT_PROFILE_CLAIM_PATH } from "../constants.js";
 import { isRecord } from "../utils.js";
 import type { AccountIdSource, JWTPayload } from "../types.js";
 
@@ -57,6 +57,41 @@ function formatAccountIdSuffix(accountId: string): string {
 function formatTokenCandidateLabel(prefix: string, accountId: string): string {
 	const suffix = formatAccountIdSuffix(accountId);
 	return `${prefix} [id:${suffix}]`;
+}
+
+/**
+ * Trailing `[id:…]` marks a label this plugin generated. A user-supplied label
+ * never carries one, which is what lets a login refresh a stale generated
+ * label without overwriting a name someone chose.
+ */
+const GENERATED_LABEL_PATTERN = /\s\[id:[^\]]*\]$/;
+
+/**
+ * The account label for a ChatGPT-backed credential.
+ *
+ * A ChatGPT OAuth token names no workspace: it carries `chatgpt_account_id`
+ * (the workspace) and `chatgpt_account_user_id` (the seat), and nothing else
+ * that identifies either. Email plus the account id suffix is therefore the
+ * most identifying label the credential supports, and it keeps two seats of
+ * one Business workspace distinguishable.
+ */
+export function formatChatGptAccountLabel(
+	email: string | undefined,
+	accountId: string | undefined,
+): string | undefined {
+	const normalizedEmail = toStringValue(email);
+	const normalizedAccountId = toStringValue(accountId);
+	if (normalizedAccountId) {
+		const suffix = `id:${formatAccountIdSuffix(normalizedAccountId)}`;
+		return normalizedEmail ? `${normalizedEmail} ${suffix}` : suffix;
+	}
+	return normalizedEmail;
+}
+
+export function isGeneratedAccountLabel(label: string | undefined): boolean {
+	const normalized = toStringValue(label);
+	if (!normalized) return true;
+	return GENERATED_LABEL_PATTERN.test(normalized);
 }
 
 /**
@@ -448,9 +483,16 @@ export function extractAccountEmail(accessToken?: string, idToken?: string): str
 	if (!accessToken) return undefined;
 	const decoded = decodeJWT(accessToken);
 	const nested = decoded?.[JWT_CLAIM_PATH] as Record<string, unknown> | undefined;
+	// The profile claim is the only email an access token carries on its own, so
+	// it is what keeps the address recoverable on a refresh that returns no
+	// id_token.
+	const profile = decoded?.[JWT_PROFILE_CLAIM_PATH] as
+		| Record<string, unknown>
+		| undefined;
 	const candidate =
 		(nested?.email as string | undefined) ??
 		(nested?.chatgpt_user_email as string | undefined) ??
+		(profile?.email as string | undefined) ??
 		(decoded?.email as string | undefined) ??
 		(decoded?.preferred_username as string | undefined);
 	if (typeof candidate === "string" && candidate.includes("@") && candidate.trim()) {
@@ -499,26 +541,6 @@ export function getAccountIdCandidates(
 	}
 
 	return uniqueCandidates(candidates);
-}
-
-/**
- * Re-point a candidate label at the account id that actually routes requests.
- *
- * Candidate labels embed their own `[id:…]` suffix, and for an org candidate
- * that suffix is the organization id - which the Codex backend ignores when it
- * meters quota. Swapping in the routing account's suffix keeps the workspace
- * name a user recognises while identifying the entry the same way every other
- * surface does.
- */
-export function relabelCandidateForAccountId(
-	label: string | undefined,
-	accountId: string,
-): string | undefined {
-	if (!label) return undefined;
-	const base = label.replace(/\s*\[id:[^\]]*\]\s*$/, "").trim();
-	return base
-		? `${base} [id:${formatAccountIdSuffix(accountId)}]`
-		: formatTokenCandidateLabel("Workspace", accountId);
 }
 
 /**

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -63,6 +63,9 @@ export const URL_PATHS = {
 /** JWT claim path for ChatGPT account ID */
 export const JWT_CLAIM_PATH = "https://api.openai.com/auth" as const;
 
+/** JWT claim path carrying the signed-in user's email; present on access tokens. */
+export const JWT_PROFILE_CLAIM_PATH = "https://api.openai.com/profile" as const;
+
 /** Error messages */
 export const ERROR_MESSAGES = {
 	NO_ACCOUNT_ID: "Failed to extract accountId from token",

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -130,6 +130,7 @@ export const AccountMetadataV3Schema = z.object({
 	organizationId: z.string().optional(),
 	accountIdSource: AccountIdSourceSchema.optional(),
 	accountLabel: z.string().optional(),
+	planType: z.string().optional(),
 	accountTags: AccountTagsSchema,
 	accountNote: AccountNoteSchema,
 	email: z.string().optional(),

--- a/lib/storage/flagged.ts
+++ b/lib/storage/flagged.ts
@@ -129,6 +129,11 @@ function normalizeFlaggedStorage(data: unknown): FlaggedAccountStorageV1 {
         ),
       accountIdSource,
       accountLabel: typeof rawAccount.accountLabel === "string" ? rawAccount.accountLabel : undefined,
+      // Carried like accountLabel: this normalizer rebuilds records field by
+      // field, so a field it does not name is dropped on the way through
+      // quarantine and the restored account reports an unknown plan until the
+      // next login or token refresh.
+      planType: typeof rawAccount.planType === "string" ? rawAccount.planType : undefined,
       accountTags,
       accountNote,
       email: typeof rawAccount.email === "string" ? rawAccount.email : undefined,

--- a/lib/storage/migrations.ts
+++ b/lib/storage/migrations.ts
@@ -109,6 +109,8 @@ export interface AccountMetadataV3 {
 	organizationId?: string;
 	accountIdSource?: AccountIdSource;
 	accountLabel?: string;
+	/** `chatgpt_plan_type` from the access token, e.g. `pro` or `team`. */
+	planType?: string;
 	accountTags?: string[];
 	accountNote?: string;
 	email?: string;

--- a/lib/tools/codex-limits.ts
+++ b/lib/tools/codex-limits.ts
@@ -25,6 +25,7 @@ import {
 	formatUiKeyValue,
 } from "../ui/format.js";
 import { normalizeToolOutputFormat, renderJsonOutput } from "../runtime.js";
+import { formatPlanType } from "../auth/plan-tier.js";
 import type { ToolContext } from "./index.js";
 
 /**
@@ -234,9 +235,10 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 								`  ${formatUiKeyValue(ui, limit.name, formatUsageLimitSummary(limit.window), "muted")}`,
 							);
 						}
-						if (usage.planType) {
+						const planLabel = formatPlanType(usage.planType);
+						if (planLabel) {
 							lines.push(
-								`  ${formatUiKeyValue(ui, "Plan", usage.planType, "muted")}`,
+								`  ${formatUiKeyValue(ui, "Plan", planLabel, "muted")}`,
 							);
 						}
 						if (usage.credits) {
@@ -262,8 +264,9 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 								`  ${limit.name}: ${formatUsageLimitSummary(limit.window)}`,
 							);
 						}
-						if (usage.planType) {
-							lines.push(`  Plan: ${usage.planType}`);
+						const planLabel = formatPlanType(usage.planType);
+						if (planLabel) {
+							lines.push(`  Plan: ${planLabel}`);
 						}
 						if (usage.credits) {
 							lines.push(`  Credits: ${usage.credits}`);

--- a/lib/tools/codex-list.ts
+++ b/lib/tools/codex-list.ts
@@ -16,6 +16,7 @@ import {
 	paintUiText,
 } from "../ui/format.js";
 import { normalizeToolOutputFormat, renderJsonOutput } from "../runtime.js";
+import { formatPlanType } from "../auth/plan-tier.js";
 import type { ToolContext } from "./index.js";
 
 export function createCodexListTool(ctx: ToolContext): ToolDefinition {
@@ -178,6 +179,8 @@ export function createCodexListTool(ctx: ToolContext): ToolDefinition {
 							}),
 							enabled: account.enabled !== false,
 							isActive: index === activeIndex,
+							planType: account.planType ?? null,
+							plan: formatPlanType(account.planType) ?? null,
 							rateLimit: rateLimit ?? null,
 							cooldown: cooldown ?? null,
 							tags: Array.isArray(account.accountTags)
@@ -221,6 +224,8 @@ export function createCodexListTool(ctx: ToolContext): ToolDefinition {
 					if (badges.length === 0) {
 						badges.push(formatUiBadge(ui, "ok", "success"));
 					}
+					const plan = formatPlanType(account.planType);
+					if (plan) badges.push(formatUiBadge(ui, plan, "muted"));
 
 					lines.push(
 						formatUiItem(ui, `${label} ${badges.join(" ")}`.trim()),
@@ -273,6 +278,7 @@ export function createCodexListTool(ctx: ToolContext): ToolDefinition {
 				columns: [
 					{ header: "#", width: 3 },
 					{ header: "Label", width: 42 },
+					{ header: "Plan", width: 18 },
 					{ header: "Status", width: 20 },
 				],
 			};
@@ -299,7 +305,12 @@ export function createCodexListTool(ctx: ToolContext): ToolDefinition {
 					statuses.length > 0 ? statuses.join(", ") : "ok";
 				lines.push(
 					buildTableRow(
-						[String(index + 1), label, statusText],
+						[
+							String(index + 1),
+							label,
+							formatPlanType(account.planType) ?? "unknown",
+							statusText,
+						],
 						listTableOptions,
 					),
 				);

--- a/lib/tools/codex-status.ts
+++ b/lib/tools/codex-status.ts
@@ -21,6 +21,7 @@ import {
 	formatUiSection,
 } from "../ui/format.js";
 import { normalizeToolOutputFormat, renderJsonOutput } from "../runtime.js";
+import { formatPlanType } from "../auth/plan-tier.js";
 import type { ToolContext } from "./index.js";
 
 export function createCodexStatusTool(ctx: ToolContext): ToolDefinition {
@@ -142,6 +143,8 @@ export function createCodexStatusTool(ctx: ToolContext): ToolDefinition {
 						}),
 						enabled: account.enabled !== false,
 						isActive: index === activeIndex,
+						planType: account.planType ?? null,
+						plan: formatPlanType(account.planType) ?? null,
 						rateLimit: formatRateLimitEntry(account, now) ?? null,
 						cooldown: formatCooldown(account, now) ?? null,
 						lastUsedAgeMs:

--- a/lib/tools/codex-status.ts
+++ b/lib/tools/codex-status.ts
@@ -219,6 +219,8 @@ export function createCodexStatusTool(ctx: ToolContext): ToolDefinition {
 						badges.push(formatUiBadge(ui, "cooldown", "warning"));
 					if (badges.length === 0)
 						badges.push(formatUiBadge(ui, "ok", "success"));
+					const plan = formatPlanType(account.planType);
+					if (plan) badges.push(formatUiBadge(ui, plan, "muted"));
 
 					lines.push(
 						formatUiItem(ui, `${label} ${badges.join(" ")}`.trim()),
@@ -294,6 +296,7 @@ export function createCodexStatusTool(ctx: ToolContext): ToolDefinition {
 				columns: [
 					{ header: "#", width: 3 },
 					{ header: "Label", width: 42 },
+					{ header: "Plan", width: 18 },
 					{ header: "Active", width: 6 },
 					{ header: "Rate Limit", width: 16 },
 					{ header: "Cooldown", width: 16 },
@@ -322,6 +325,7 @@ export function createCodexStatusTool(ctx: ToolContext): ToolDefinition {
 						[
 							String(index + 1),
 							label,
+							formatPlanType(account.planType) ?? "unknown",
 							active,
 							rateLimit,
 							cooldown,

--- a/lib/tui-status.ts
+++ b/lib/tui-status.ts
@@ -1,5 +1,6 @@
 import type { Config } from "@opencode-ai/sdk/v2";
 import { getEffortSuffix } from "./request/helpers/effort-suffix.js";
+import { formatPlanType } from "./auth/plan-tier.js";
 
 export type ReasoningVariant =
 	| "none"
@@ -450,7 +451,10 @@ export function formatQuotaDetailsText(
 	for (const limit of quota.limits) {
 		lines.push(formatDetailsLimit(limit));
 	}
-	if (quota.planType) lines.push(`Plan: ${quota.planType}`);
+	// Named through formatPlanType like the stored copy, so one seat does not
+	// print "Business" in codex-list and "team" here in the same session.
+	const planLabel = formatPlanType(quota.planType);
+	if (planLabel) lines.push(`Plan: ${planLabel}`);
 	if (
 		typeof quota.activeLimit === "number" &&
 		Number.isFinite(quota.activeLimit)

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -73,6 +73,7 @@ export interface JWTPayload {
 	"https://api.openai.com/auth"?: {
 		chatgpt_account_id?: string;
 		chatgpt_account_user_id?: string;
+		chatgpt_plan_type?: string;
 		organizations?: unknown;
 		email?: string;
 		chatgpt_user_email?: string;

--- a/test/accounts-dispose-cancels-save.test.ts
+++ b/test/accounts-dispose-cancels-save.test.ts
@@ -1,13 +1,19 @@
 /**
- * `disposeShutdownHandler()` tears a manager's process-level side effects down.
- * A debounced save armed before that call is one of them: it fires up to 500ms
- * later and writes the manager's in-memory snapshot to the account file.
+ * `disposeShutdownHandler()` marks a manager as replaced. A debounced save
+ * armed before that call fires up to 500ms later; a save that had already
+ * started cannot be stopped at all.
  *
- * That snapshot is authoritative for account *membership*. `saveToDisk` adopts
- * newer credentials and longer rate-limit blocks from disk, but never adopts
- * disk accounts the snapshot lacks, so a replaced manager firing late does not
- * merely lose a rotation stamp: it deletes every account its successor has that
- * the dead one did not.
+ * The manager's snapshot is authoritative for account *membership*.
+ * `saveToDisk` adopts newer credentials and longer rate-limit blocks from disk,
+ * but never adopts disk accounts the snapshot lacks, so a replaced manager
+ * writing it late does not merely lose a rotation stamp: it deletes every
+ * account its successor has that the dead one did not.
+ *
+ * Dropping the write outright is not the answer either. The only save a
+ * cancel can still reach is one armed *after* the caller's flush, and that is
+ * the rate-limit block an in-flight request just recorded — losing it hands an
+ * exhausted account straight back to rotation. So a disposed manager still
+ * writes, with membership and credentials taken from disk.
  */
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
@@ -48,11 +54,19 @@ function managerWithForeignAccount(): AccountManager {
 	return manager;
 }
 
+/** A manager holding an account the on-disk store also has. */
+function managerSharingDiskAccount(): AccountManager {
+	const manager = new AccountManager(undefined, storageOf([ON_DISK_ACCOUNTS[0]]));
+	managers.push(manager);
+	return manager;
+}
+
+async function readStored(): Promise<AccountStorageV3> {
+	return JSON.parse(await fs.readFile(TEST_STORAGE_PATH, "utf8")) as AccountStorageV3;
+}
+
 async function storedRefreshTokens(): Promise<string[]> {
-	const raw = JSON.parse(
-		await fs.readFile(TEST_STORAGE_PATH, "utf8"),
-	) as AccountStorageV3;
-	return raw.accounts.map((account) => account.refreshToken);
+	return (await readStored()).accounts.map((account) => account.refreshToken);
 }
 
 const sleep = (ms: number): Promise<void> =>
@@ -66,14 +80,18 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-	// Dispose while the override is still active, so nothing can outlive it.
-	for (const manager of managers.splice(0)) manager.disposeShutdownHandler();
+	// Dispose and drain while the override is still active, so no write can
+	// resolve the storage path after it is cleared.
+	for (const manager of managers.splice(0)) {
+		manager.disposeShutdownHandler();
+		await manager.flushPendingSave();
+	}
 	setStoragePathDirect(null);
 	await fs.rm(TEST_STORAGE_PATH, { force: true });
 });
 
 describe("AccountManager.disposeShutdownHandler", () => {
-	it("does not write the account file after the debounce window", async () => {
+	it("keeps the store's account membership when a queued save fires after disposal", async () => {
 		// Given a store holding accounts this manager knows nothing about
 		const manager = managerWithForeignAccount();
 
@@ -98,5 +116,63 @@ describe("AccountManager.disposeShutdownHandler", () => {
 		// assertion above is about disposal rather than about a save that never
 		// had a chance to fire
 		await expect(storedRefreshTokens()).resolves.toEqual(["rt-from-a-dead-manager"]);
+	});
+
+	it("keeps membership when a save was already in flight at disposal", async () => {
+		// Given a save that has already started, so no timer cancel can reach it
+		const manager = managerWithForeignAccount();
+		const inFlight = manager.saveToDisk();
+
+		// When disposal lands before the storage transaction runs
+		manager.disposeShutdownHandler();
+		await inFlight;
+
+		// Then the store still holds exactly the accounts it started with
+		await expect(storedRefreshTokens()).resolves.toEqual([...ON_DISK_ACCOUNTS]);
+	});
+
+	it("still persists a rate-limit block recorded after the caller's flush", async () => {
+		// Given a manager that shares an account with the store, flushed clean
+		const manager = managerSharingDiskAccount();
+		await manager.flushPendingSave();
+
+		// When an in-flight request records a 429 on it and the reload disposes
+		// it before the debounce fires
+		const account = manager.getCurrentOrNextForFamilyHybrid("codex", "gpt-5.1");
+		expect(account).not.toBeNull();
+		manager.markRateLimited(account!, 60 * 60_000, "codex", "gpt-5.1");
+		manager.saveToDiskDebounced();
+		manager.disposeShutdownHandler();
+		await sleep(PAST_DEBOUNCE_MS);
+
+		// Then the block reached disk — dropping it would hand an exhausted
+		// account straight back to rotation — and membership is untouched
+		const stored = await readStored();
+		expect(stored.accounts.map((entry) => entry.refreshToken)).toEqual([...ON_DISK_ACCOUNTS]);
+		const blocked = stored.accounts.find(
+			(entry) => entry.refreshToken === ON_DISK_ACCOUNTS[0],
+		);
+		const resets = Object.values(blocked?.rateLimitResetTimes ?? {});
+		expect(resets.length).toBeGreaterThan(0);
+		expect(Math.max(...(resets as number[]))).toBeGreaterThan(Date.now());
+	});
+
+	it("leaves an unrelated account's credentials alone while doing so", async () => {
+		// Given a disposed manager whose snapshot omits two on-disk accounts
+		const manager = managerSharingDiskAccount();
+		await manager.flushPendingSave();
+		const account = manager.getCurrentOrNextForFamilyHybrid("codex", "gpt-5.1");
+		manager.markRateLimited(account!, 60 * 60_000, "codex", "gpt-5.1");
+		manager.saveToDiskDebounced();
+		manager.disposeShutdownHandler();
+		await sleep(PAST_DEBOUNCE_MS);
+
+		// Then the accounts it never held keep their own records verbatim
+		const stored = await readStored();
+		for (const refreshToken of ON_DISK_ACCOUNTS.slice(1)) {
+			const untouched = stored.accounts.find((entry) => entry.refreshToken === refreshToken);
+			expect(untouched?.rateLimitResetTimes).toBeUndefined();
+			expect(untouched?.coolingDownUntil).toBeUndefined();
+		}
 	});
 });

--- a/test/accounts-dispose-cancels-save.test.ts
+++ b/test/accounts-dispose-cancels-save.test.ts
@@ -1,0 +1,102 @@
+/**
+ * `disposeShutdownHandler()` tears a manager's process-level side effects down.
+ * A debounced save armed before that call is one of them: it fires up to 500ms
+ * later and writes the manager's in-memory snapshot to the account file.
+ *
+ * That snapshot is authoritative for account *membership*. `saveToDisk` adopts
+ * newer credentials and longer rate-limit blocks from disk, but never adopts
+ * disk accounts the snapshot lacks, so a replaced manager firing late does not
+ * merely lose a rotation stamp: it deletes every account its successor has that
+ * the dead one did not.
+ */
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { AccountManager } from "../lib/accounts.js";
+import { setStoragePathDirect, type AccountStorageV3 } from "../lib/storage.js";
+
+/** Longer than the 500ms debounce, short enough to keep the suite fast. */
+const PAST_DEBOUNCE_MS = 900;
+
+const TEST_STORAGE_PATH = join(
+	tmpdir(),
+	`oc-codex-multi-auth-dispose-cancels-save-${process.pid}-${Date.now()}.json`,
+);
+
+const ON_DISK_ACCOUNTS = ["rt-user-1", "rt-user-2", "rt-user-3"] as const;
+
+const managers: AccountManager[] = [];
+
+function storageOf(refreshTokens: readonly string[]): AccountStorageV3 {
+	return {
+		version: 3,
+		activeIndex: 0,
+		accounts: refreshTokens.map((refreshToken, index) => ({
+			refreshToken,
+			addedAt: 1_700_000_000_000,
+			lastUsed: 1_700_000_000_000 + index,
+		})),
+	};
+}
+
+/** A manager holding one account the on-disk store does not have. */
+function managerWithForeignAccount(): AccountManager {
+	const manager = new AccountManager(undefined, storageOf(["rt-from-a-dead-manager"]));
+	managers.push(manager);
+	return manager;
+}
+
+async function storedRefreshTokens(): Promise<string[]> {
+	const raw = JSON.parse(
+		await fs.readFile(TEST_STORAGE_PATH, "utf8"),
+	) as AccountStorageV3;
+	return raw.accounts.map((account) => account.refreshToken);
+}
+
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+beforeEach(async () => {
+	// Redirect account storage before any manager exists, so no save in this
+	// file can reach the developer's real account file.
+	setStoragePathDirect(TEST_STORAGE_PATH);
+	await fs.writeFile(TEST_STORAGE_PATH, JSON.stringify(storageOf(ON_DISK_ACCOUNTS)));
+});
+
+afterEach(async () => {
+	// Dispose while the override is still active, so nothing can outlive it.
+	for (const manager of managers.splice(0)) manager.disposeShutdownHandler();
+	setStoragePathDirect(null);
+	await fs.rm(TEST_STORAGE_PATH, { force: true });
+});
+
+describe("AccountManager.disposeShutdownHandler", () => {
+	it("does not write the account file after the debounce window", async () => {
+		// Given a store holding accounts this manager knows nothing about
+		const manager = managerWithForeignAccount();
+
+		// When a queued save is followed by disposal
+		manager.saveToDiskDebounced();
+		manager.disposeShutdownHandler();
+		await sleep(PAST_DEBOUNCE_MS);
+
+		// Then the store still holds exactly the accounts it started with
+		await expect(storedRefreshTokens()).resolves.toEqual([...ON_DISK_ACCOUNTS]);
+	});
+
+	it("is the only thing preventing that write", async () => {
+		// Given the same store and an identical queued save
+		const manager = managerWithForeignAccount();
+
+		// When the manager is left live instead of disposed
+		manager.saveToDiskDebounced();
+		await sleep(PAST_DEBOUNCE_MS);
+
+		// Then the save lands and replaces the store's accounts, so the
+		// assertion above is about disposal rather than about a save that never
+		// had a chance to fire
+		await expect(storedRefreshTokens()).resolves.toEqual(["rt-from-a-dead-manager"]);
+	});
+});

--- a/test/chaos/auth-invalidated-401-stress.test.ts
+++ b/test/chaos/auth-invalidated-401-stress.test.ts
@@ -22,10 +22,13 @@
  *      NOT misfire on rate-limit / entitlement / server bodies.
  */
 
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, afterAll, afterEach, beforeAll, vi } from "vitest";
 
 import { AccountManager } from "../../lib/accounts.js";
-import type { AccountStorageV3 } from "../../lib/storage.js";
+import { setStoragePathDirect, type AccountStorageV3 } from "../../lib/storage.js";
 import { ACCOUNT_LIMITS } from "../../lib/constants.js";
 import { isInvalidatedAuthTokenError } from "../../lib/request/fetch-helpers.js";
 import type { ModelFamily } from "../../lib/prompts/codex.js";
@@ -33,6 +36,15 @@ import { MODEL_FAMILIES } from "../../lib/prompts/codex.js";
 
 const FAMILY: ModelFamily = "codex";
 const COOLDOWN = ACCOUNT_LIMITS.AUTH_FAILURE_COOLDOWN_MS;
+
+// These scenarios drive the REAL AccountManager and end in
+// saveToDiskDebounced(), which without this override replaces the developer's
+// own ~/.opencode account pool with this file's fixture. Pid-scoped so
+// concurrent checkouts do not share one file.
+const TEST_STORAGE_PATH = join(
+	tmpdir(),
+	`oc-codex-multi-auth-auth-invalidated-401-${process.pid}-${Date.now()}.json`,
+);
 
 const INVALIDATED_401_BODY = {
 	error: {
@@ -133,6 +145,19 @@ function simulateRestart(manager: AccountManager): AccountManager {
 }
 
 describe("chaos/auth-invalidated-401 — real manager + real detector (issue #171)", () => {
+	beforeAll(() => {
+		setStoragePathDirect(TEST_STORAGE_PATH);
+	});
+
+	afterAll(async () => {
+		setStoragePathDirect(null);
+		try {
+			await fs.unlink(TEST_STORAGE_PATH);
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		}
+	});
+
 	afterEach(() => {
 		vi.restoreAllMocks();
 		vi.useRealTimers();

--- a/test/chaos/auth-invalidated-401-stress.test.ts
+++ b/test/chaos/auth-invalidated-401-stress.test.ts
@@ -46,6 +46,21 @@ const TEST_STORAGE_PATH = join(
 	`oc-codex-multi-auth-auth-invalidated-401-${process.pid}-${Date.now()}.json`,
 );
 
+/**
+ * Every manager this file builds, so `afterEach` can drain its debounced saves
+ * before the storage override is cleared. Redirecting the path is not enough on
+ * its own: `saveToDisk` resolves `getStoragePath()` inside the transaction, so
+ * a save still in flight when `setStoragePathDirect(null)` runs would land on
+ * the developer's real `~/.opencode` account file.
+ */
+const managers: AccountManager[] = [];
+
+function createManager(storage: AccountStorageV3): AccountManager {
+	const manager = new AccountManager(undefined, storage);
+	managers.push(manager);
+	return manager;
+}
+
 const INVALIDATED_401_BODY = {
 	error: {
 		message:
@@ -141,7 +156,7 @@ function simulateRestart(manager: AccountManager): AccountManager {
 			cooldownReason: a.cooldownReason,
 		})),
 	};
-	return new AccountManager(undefined, storage);
+	return createManager(storage);
 }
 
 describe("chaos/auth-invalidated-401 — real manager + real detector (issue #171)", () => {
@@ -158,15 +173,21 @@ describe("chaos/auth-invalidated-401 — real manager + real detector (issue #17
 		}
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		vi.restoreAllMocks();
+		// Real timers first: these cases run on fake timers, and the debounced
+		// save below never fires while the clock is frozen.
 		vi.useRealTimers();
+		for (const manager of managers.splice(0)) {
+			manager.disposeShutdownHandler();
+			await manager.flushPendingSave();
+		}
 	});
 
 	it("A: 401 on the pinned slot cools it down and rotation returns a different healthy account", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date(1_700_000_000_000));
-		const manager = new AccountManager(undefined, makeTwoAccountStorage());
+		const manager = createManager(makeTwoAccountStorage());
 
 		const dead = manager.getCurrentOrNextForFamilyHybrid(FAMILY, "gpt-5.1");
 		expect(dead).not.toBeNull();
@@ -191,7 +212,7 @@ describe("chaos/auth-invalidated-401 — real manager + real detector (issue #17
 	it("B: after success on the healthy account, persisted family routing points at it (self-heals across restart)", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date(1_700_000_000_000));
-		const manager = new AccountManager(undefined, makeTwoAccountStorage());
+		const manager = createManager(makeTwoAccountStorage());
 
 		// Family is pinned to the dead slot (index 0) initially — the #171 bug.
 		expect(manager.getActiveIndexForFamily(FAMILY)).toBe(0);
@@ -220,7 +241,7 @@ describe("chaos/auth-invalidated-401 — real manager + real detector (issue #17
 	});
 
 	it("C: clearAuthFailures on success prevents stale-count accumulation toward removal", async () => {
-		const manager = new AccountManager(undefined, makeTwoAccountStorage());
+		const manager = createManager(makeTwoAccountStorage());
 		const dead = manager.getCurrentOrNextForFamilyHybrid(FAMILY, "gpt-5.1")!;
 
 		// Two 401s (below the threshold of 3).
@@ -243,7 +264,7 @@ describe("chaos/auth-invalidated-401 — real manager + real detector (issue #17
 	});
 
 	it("D: reaching MAX_AUTH_FAILURES_BEFORE_REMOVAL removes the dead refresh-token group", async () => {
-		const manager = new AccountManager(undefined, makeTwoAccountStorage());
+		const manager = createManager(makeTwoAccountStorage());
 		const dead = manager.getCurrentOrNextForFamilyHybrid(FAMILY, "gpt-5.1")!;
 
 		let last = { removed: 0, cooledCount: 0, failures: 0 };
@@ -264,7 +285,7 @@ describe("chaos/auth-invalidated-401 — real manager + real detector (issue #17
 	it("E: single standalone account 401 exercises the cooledCount fallback and cools the lone account", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date(1_700_000_000_000));
-		const manager = new AccountManager(undefined, makeSingleAccountStorage());
+		const manager = createManager(makeSingleAccountStorage());
 		const solo = manager.getCurrentOrNextForFamilyHybrid(FAMILY, "gpt-5.1")!;
 		expect(solo.refreshToken).toBe("rt-solo");
 
@@ -293,7 +314,7 @@ describe("chaos/auth-invalidated-401 — real manager + real detector (issue #17
 	it("E2: explicit fallback — markAccountCoolingDown fires when no token group matches", () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date(1_700_000_000_000));
-		const manager = new AccountManager(undefined, makeSingleAccountStorage());
+		const manager = createManager(makeSingleAccountStorage());
 		const solo = manager.getCurrentOrNextForFamilyHybrid(FAMILY, "gpt-5.1")!;
 
 		// Simulate the cooledCount<=0 branch directly: a token with no live match.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6156,9 +6156,10 @@ describe("OpenAIOAuthPlugin persistAccountPool", () => {
 		expect(mockStorage.accounts).toHaveLength(1);
 		expect(mockStorage.accounts[0]?.accountId).toBe("token-personal");
 		expect(mockStorage.accounts[0]?.accountIdSource).toBe("token");
-		// The selected workspace's name survives, re-suffixed with the id that
-		// actually identifies the entry.
-		expect(mockStorage.accounts[0]?.accountLabel).toBe("Workspace Alpha [id:rsonal]");
+		// The candidate name is an API-platform organization, not a ChatGPT
+		// workspace, so the label is built from the identity the credential
+		// actually carries.
+		expect(mockStorage.accounts[0]?.accountLabel).toBe("user@example.com id:rsonal");
 		// organizationId is display/dedupe metadata only - it is not sent as a
 		// header unless CODEX_AUTH_SEND_ORGANIZATION_HEADER=1.
 		expect(mockStorage.accounts[0]?.organizationId).toBe("org-default");
@@ -6197,9 +6198,9 @@ describe("OpenAIOAuthPlugin persistAccountPool", () => {
 			"token-first",
 		]);
 		expect(mockStorage.accounts[0]?.accountIdSource).toBe("token");
-		// The preferred workspace still names the entry and supplies its org id.
+		// The preferred organization still supplies the org id, but not the name.
 		expect(mockStorage.accounts[0]?.organizationId).toBe("org-preferred");
-		expect(mockStorage.accounts[0]?.accountLabel).toBe("Org Preferred [id:-first]");
+		expect(mockStorage.accounts[0]?.accountLabel).toBe("user@example.com id:-first");
 	});
 
 	it("collapses duplicate organization candidates onto the single token account", async () => {
@@ -6246,7 +6247,7 @@ describe("OpenAIOAuthPlugin persistAccountPool", () => {
 		expect(mockStorage.accounts).toHaveLength(1);
 		expect(mockStorage.accounts[0]?.accountId).toBe("token-personal");
 		expect(mockStorage.accounts[0]?.organizationId).toBe("organization-shared");
-		expect(mockStorage.accounts[0]?.accountLabel).toBe("Org Shared A [id:rsonal]");
+		expect(mockStorage.accounts[0]?.accountLabel).toBe("user@example.com id:rsonal");
 	});
 
 	it("persists a single token-scoped entry when a login yields org and token candidates", async () => {
@@ -6300,8 +6301,10 @@ describe("OpenAIOAuthPlugin persistAccountPool", () => {
 		expect(mockStorage.accounts[0]?.organizationId).toBe(
 			"org-QA1bZCn6zb57FT6TXLZWMPO3",
 		);
+		// "Personal (role:owner)" is the API org's own name and role, which named
+		// every ChatGPT account this way regardless of its real subscription.
 		expect(mockStorage.accounts[0]?.accountLabel).toBe(
-			"Personal (role:owner) [id:3c2a4a]",
+			"user@example.com id:3c2a4a",
 		);
 		expect(mockStorage.accounts[0]?.refreshToken).toBe("refresh-holly-shared");
 	});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1382,6 +1382,24 @@ describe("OpenAIOAuthPlugin", () => {
 			expect(result).toContain("Active index by model family");
 		});
 
+		it("shows the plan in the default output, not only in JSON", async () => {
+			// README documents the plan as shown by codex-list AND codex-status.
+			// It reached only the JSON payload, so the default view contradicted
+			// the documented capability.
+			mockStorage.accounts = [
+				{
+					refreshToken: "r1",
+					email: "user@example.com",
+					accountId: "acc-1",
+					planType: "self_serve_business_prolite",
+				},
+			];
+			mockStorage.activeIndexByFamily = { codex: 0 };
+			const result = (await plugin.tool["codex-status"].execute()) as string;
+			expect(result).toContain("Business Premium");
+			expect(result).not.toContain("self_serve_business_prolite");
+		});
+
 		it("returns json output for account status", async () => {
 			mockStorage.accounts = [
 				{ refreshToken: "r1", email: "user@example.com", accountId: "acc-1" },
@@ -1472,7 +1490,9 @@ describe("OpenAIOAuthPlugin", () => {
 			expect(result).toContain("5h limit: 87% left");
 			expect(result).toContain("Weekly limit: 64% left");
 			expect(result).toContain("Code review: 100% left");
-			expect(result).toContain("Plan: team");
+			// Named, not echoed: the same seat must not read "Business" in
+			// codex-list and "team" here.
+			expect(result).toContain("Plan: Business");
 			expect(result).toContain("Credits: unlimited");
 			expect(globalThis.fetch).toHaveBeenCalledWith(
 				"https://chatgpt.com/backend-api/wham/usage",
@@ -6157,9 +6177,10 @@ describe("OpenAIOAuthPlugin persistAccountPool", () => {
 		expect(mockStorage.accounts[0]?.accountId).toBe("token-personal");
 		expect(mockStorage.accounts[0]?.accountIdSource).toBe("token");
 		// The candidate name is an API-platform organization, not a ChatGPT
-		// workspace, so the label is built from the identity the credential
-		// actually carries.
-		expect(mockStorage.accounts[0]?.accountLabel).toBe("user@example.com id:rsonal");
+		// workspace, so no label is generated from it. Email and account id are
+		// already stored as their own fields and rendered from there, masked.
+		expect(mockStorage.accounts[0]?.accountLabel).toBeUndefined();
+		expect(mockStorage.accounts[0]?.email).toBe("user@example.com");
 		// organizationId is display/dedupe metadata only - it is not sent as a
 		// header unless CODEX_AUTH_SEND_ORGANIZATION_HEADER=1.
 		expect(mockStorage.accounts[0]?.organizationId).toBe("org-default");
@@ -6200,7 +6221,7 @@ describe("OpenAIOAuthPlugin persistAccountPool", () => {
 		expect(mockStorage.accounts[0]?.accountIdSource).toBe("token");
 		// The preferred organization still supplies the org id, but not the name.
 		expect(mockStorage.accounts[0]?.organizationId).toBe("org-preferred");
-		expect(mockStorage.accounts[0]?.accountLabel).toBe("user@example.com id:-first");
+		expect(mockStorage.accounts[0]?.accountLabel).toBeUndefined();
 	});
 
 	it("collapses duplicate organization candidates onto the single token account", async () => {
@@ -6247,7 +6268,7 @@ describe("OpenAIOAuthPlugin persistAccountPool", () => {
 		expect(mockStorage.accounts).toHaveLength(1);
 		expect(mockStorage.accounts[0]?.accountId).toBe("token-personal");
 		expect(mockStorage.accounts[0]?.organizationId).toBe("organization-shared");
-		expect(mockStorage.accounts[0]?.accountLabel).toBe("user@example.com id:rsonal");
+		expect(mockStorage.accounts[0]?.accountLabel).toBeUndefined();
 	});
 
 	it("persists a single token-scoped entry when a login yields org and token candidates", async () => {
@@ -6302,10 +6323,10 @@ describe("OpenAIOAuthPlugin persistAccountPool", () => {
 			"org-QA1bZCn6zb57FT6TXLZWMPO3",
 		);
 		// "Personal (role:owner)" is the API org's own name and role, which named
-		// every ChatGPT account this way regardless of its real subscription.
-		expect(mockStorage.accounts[0]?.accountLabel).toBe(
-			"user@example.com id:3c2a4a",
-		);
+		// every ChatGPT account this way regardless of its real subscription. No
+		// label replaces it: the email and account id fields already carry the
+		// identity, and every surface renders them.
+		expect(mockStorage.accounts[0]?.accountLabel).toBeUndefined();
 		expect(mockStorage.accounts[0]?.refreshToken).toBe("refresh-holly-shared");
 	});
 

--- a/test/login-runner.test.ts
+++ b/test/login-runner.test.ts
@@ -594,9 +594,41 @@ describe("login-runner account and quota identities", () => {
 		expect(selection.variantsForPersistence[0]).toBe(selection.primary);
 		expect(selection.primary.accountIdOverride).toBe("chatgpt-team-account");
 		expect(selection.primary.accountIdSource).toBe("token");
-		// The active workspace still supplies the name and org id.
+		// The active organization still supplies the org id used for dedupe.
 		expect(selection.primary.organizationIdOverride).toBe("org-acme");
-		expect(selection.primary.accountLabel).toBe("Acme [id:ccount]");
+		// ...but not the label: those organizations are the API-platform orgs
+		// `id_token_add_organizations=true` returns, not ChatGPT workspaces.
+		expect(selection.primary.accountLabel).toBe("id:ccount");
+		expect(selection.primary.accountLabel).not.toContain("Acme");
+	});
+
+	it("labels an account by its ChatGPT identity, never by an API organization", () => {
+		const selection = resolveAccountSelection({
+			type: "success",
+			access: encodeJwt({
+				[JWT_CLAIM_PATH]: {
+					chatgpt_account_id: "2aae3eeb-f7fd-4b2d-96c1-413d33c487c4",
+					chatgpt_plan_type: "pro",
+				},
+				email: "oferty@nowaker.net",
+			}),
+			refresh: "refresh-personal",
+			expires: Date.now() + 60_000,
+			idToken: idTokenFor([
+				{
+					organization_id: "org-yRC81tihk0WYRlMQpBEW4A2Q",
+					name: "DreamHost API",
+					role: "owner",
+					is_default: true,
+					is_personal: false,
+				},
+			]),
+		});
+
+		expect(selection.primary.accountLabel).toBe("oferty@nowaker.net id:c487c4");
+		expect(selection.primary.accountLabel).not.toContain("DreamHost API");
+		expect(selection.primary.accountLabel).not.toContain("role:");
+		expect(selection.primary.planType).toBe("pro");
 	});
 
 	it("gives each workspace login its own entry, token and quota", async () => {

--- a/test/login-runner.test.ts
+++ b/test/login-runner.test.ts
@@ -598,11 +598,10 @@ describe("login-runner account and quota identities", () => {
 		expect(selection.primary.organizationIdOverride).toBe("org-acme");
 		// ...but not the label: those organizations are the API-platform orgs
 		// `id_token_add_organizations=true` returns, not ChatGPT workspaces.
-		expect(selection.primary.accountLabel).toBe("id:ccount");
-		expect(selection.primary.accountLabel).not.toContain("Acme");
+		expect(selection.primary.accountLabel).toBeUndefined();
 	});
 
-	it("labels an account by its ChatGPT identity, never by an API organization", () => {
+	it("never names an account after an API organization", () => {
 		const selection = resolveAccountSelection({
 			type: "success",
 			access: encodeJwt({
@@ -625,9 +624,14 @@ describe("login-runner account and quota identities", () => {
 			]),
 		});
 
-		expect(selection.primary.accountLabel).toBe("oferty@nowaker.net id:c487c4");
-		expect(selection.primary.accountLabel).not.toContain("DreamHost API");
-		expect(selection.primary.accountLabel).not.toContain("role:");
+		// No label at all: "DreamHost API (role:owner)" named an API-platform
+		// organization rather than the ChatGPT subscription, and restating the
+		// email and account id here would print each identity twice and put the
+		// unmasked address back on every surface that renders a label verbatim.
+		expect(selection.primary.accountLabel).toBeUndefined();
+		expect(selection.primary.accountIdOverride).toBe(
+			"2aae3eeb-f7fd-4b2d-96c1-413d33c487c4",
+		);
 		expect(selection.primary.planType).toBe("pro");
 	});
 

--- a/test/plan-tier-persistence.test.ts
+++ b/test/plan-tier-persistence.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The stored plan tier and the stored account label are both written at login
+ * and read back on surfaces the user sees. This covers the three places where
+ * either one silently disappeared or went stale.
+ */
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { AccountManager } from "../lib/accounts.js";
+import { persistAccountPool, type TokenSuccessWithAccount } from "../lib/auth/login-runner.js";
+import { JWT_CLAIM_PATH } from "../lib/constants.js";
+import { loadAccounts, setStoragePathDirect } from "../lib/storage.js";
+import { loadFlaggedAccounts, saveFlaggedAccounts } from "../lib/storage/flagged.js";
+
+function makeToken(payload: Record<string, unknown>): string {
+	const encode = (value: unknown) =>
+		Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+	return `${encode({ alg: "none", typ: "JWT" })}.${encode(payload)}.signature`;
+}
+
+function accessTokenFor(options: { accountId: string; planType?: string; email?: string }): string {
+	return makeToken({
+		[JWT_CLAIM_PATH]: {
+			chatgpt_account_id: options.accountId,
+			...(options.planType ? { chatgpt_plan_type: options.planType } : {}),
+			...(options.email ? { email: options.email } : {}),
+		},
+	});
+}
+
+function loginResult(options: {
+	accountId: string;
+	refresh: string;
+	planType?: string;
+	email?: string;
+}): TokenSuccessWithAccount {
+	return {
+		type: "success",
+		access: accessTokenFor(options),
+		refresh: options.refresh,
+		expires: Date.now() + 60_000,
+		accountIdOverride: options.accountId,
+		accountIdSource: "token",
+	};
+}
+
+let testDir: string;
+
+beforeEach(async () => {
+	testDir = join(
+		tmpdir(),
+		`plan-tier-persistence-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	await fs.mkdir(testDir, { recursive: true });
+	setStoragePathDirect(join(testDir, "oc-codex-multi-auth-accounts.json"));
+});
+
+afterEach(async () => {
+	setStoragePathDirect(null);
+	await fs.rm(testDir, { recursive: true, force: true });
+});
+
+describe("plan tier persistence", () => {
+	it("survives a round trip through the flagged-account store", async () => {
+		// The flagged normalizer rebuilds records field by field, so a field it
+		// does not name is dropped on the way through quarantine.
+		await saveFlaggedAccounts({
+			version: 1,
+			accounts: [
+				{
+					refreshToken: "rt-quarantined",
+					accountId: "05cd9f04-d56a-4256-9934-9cb827989a40",
+					planType: "self_serve_business_prolite",
+					email: "seat@example.com",
+					addedAt: 1_700_000_000_000,
+					lastUsed: 1_700_000_000_000,
+					flaggedAt: 1_700_000_000_000,
+				},
+			],
+		});
+
+		const restored = await loadFlaggedAccounts();
+		expect(restored.accounts[0]?.planType).toBe("self_serve_business_prolite");
+	});
+
+	it("follows the access token across a refresh instead of pinning the login value", () => {
+		const manager = new AccountManager(undefined, {
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{
+					refreshToken: "rt-1",
+					accountId: "acct-1",
+					planType: "plus",
+					addedAt: 1,
+					lastUsed: 1,
+				},
+			],
+		});
+		// The live record, not a snapshot copy: updateFromAuth mutates in place.
+		const account = manager.getCurrentOrNextForFamilyHybrid("codex", "gpt-5.1");
+		expect(account).not.toBeNull();
+
+		// A Plus -> Pro upgrade arrives on the next refreshed access token. The
+		// live x-codex-plan-type header already reported the new tier, so a
+		// login-only read would leave codex-list contradicting it.
+		manager.updateFromAuth(account!, {
+			type: "oauth",
+			refresh: "rt-2",
+			access: accessTokenFor({ accountId: "acct-1", planType: "pro" }),
+			expires: Date.now() + 60_000,
+		});
+		expect(manager.getAccountsSnapshot()[0]?.planType).toBe("pro");
+
+		// A token with no claim leaves the known tier alone rather than erasing it.
+		manager.updateFromAuth(account!, {
+			type: "oauth",
+			refresh: "rt-3",
+			access: accessTokenFor({ accountId: "acct-1" }),
+			expires: Date.now() + 60_000,
+		});
+		expect(manager.getAccountsSnapshot()[0]?.planType).toBe("pro");
+	});
+});
+
+describe("account label on re-login", () => {
+	const account = {
+		accountId: "2aae3eeb-f7fd-4b2d-96c1-413d33c487c4",
+		refresh: "rt-shared",
+		email: "user@example.com",
+	};
+
+	it("clears a stale label that named an API organization", async () => {
+		await persistAccountPool([loginResult(account)], true);
+		const seeded = await loadAccounts();
+		expect(seeded?.accounts).toHaveLength(1);
+
+		// Simulate a pool written by an older version, whose label named an
+		// API-platform organization rather than the ChatGPT subscription.
+		seeded!.accounts[0]!.accountLabel = "DreamHost API (role:owner) [id:c487c4]";
+		const { saveAccounts } = await import("../lib/storage.js");
+		await saveAccounts(seeded!);
+
+		await persistAccountPool([loginResult(account)], false);
+		const stored = await loadAccounts();
+		expect(stored?.accounts[0]?.accountLabel).toBeUndefined();
+		// The identity is still there, in the fields every surface renders from.
+		expect(stored?.accounts[0]?.accountId).toBe(account.accountId);
+	});
+
+	it("keeps a label the user chose", async () => {
+		await persistAccountPool([loginResult(account)], true);
+		const seeded = await loadAccounts();
+		seeded!.accounts[0]!.accountLabel = "My work account";
+		const { saveAccounts } = await import("../lib/storage.js");
+		await saveAccounts(seeded!);
+
+		await persistAccountPool([loginResult(account)], false);
+		const stored = await loadAccounts();
+		expect(stored?.accounts[0]?.accountLabel).toBe("My work account");
+	});
+});

--- a/test/plan-tier.test.ts
+++ b/test/plan-tier.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+
+import { extractPlanType, formatPlanType } from "../lib/auth/plan-tier.js";
+import { JWT_CLAIM_PATH } from "../lib/constants.js";
+
+/**
+ * Builds an unsigned JWT whose payload decodes to `payload`. The signature is
+ * never verified by `decodeJWT`, which only base64url-decodes the middle part.
+ */
+function makeToken(payload: Record<string, unknown>): string {
+	const encode = (value: unknown) =>
+		Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+	return `${encode({ alg: "none", typ: "JWT" })}.${encode(payload)}.signature`;
+}
+
+function makeAccessToken(planType: string | undefined): string {
+	return makeToken({
+		[JWT_CLAIM_PATH]: {
+			chatgpt_account_id: "05cd9f04-d56a-4256-9934-9cb827989a40",
+			...(planType === undefined ? {} : { chatgpt_plan_type: planType }),
+		},
+	});
+}
+
+describe("extractPlanType", () => {
+	it("returns undefined without a token", () => {
+		expect(extractPlanType(undefined)).toBeUndefined();
+		expect(extractPlanType("")).toBeUndefined();
+	});
+
+	it("returns undefined for a token that is not a JWT", () => {
+		expect(extractPlanType("not-a-jwt")).toBeUndefined();
+	});
+
+	it("returns undefined when the auth claim carries no plan type", () => {
+		expect(extractPlanType(makeAccessToken(undefined))).toBeUndefined();
+	});
+
+	it("reads chatgpt_plan_type from the OpenAI auth claim", () => {
+		expect(extractPlanType(makeAccessToken("pro"))).toBe("pro");
+	});
+
+	it("trims and lowercases the claim so casing never splits a tier", () => {
+		expect(extractPlanType(makeAccessToken("  Pro  "))).toBe("pro");
+	});
+});
+
+describe("formatPlanType", () => {
+	it("returns undefined for an absent or blank plan type", () => {
+		expect(formatPlanType(undefined)).toBeUndefined();
+		expect(formatPlanType("   ")).toBeUndefined();
+	});
+
+	/**
+	 * Correlation table. Every `chatgpt_plan_type` below was read from a real
+	 * ChatGPT OAuth access token and independently confirmed against the same
+	 * account's `plan_type` from the live `/wham/usage` response, then matched
+	 * to the subscription the account owner confirmed they hold.
+	 */
+	const OBSERVED: Array<{ planType: string; expected: string; groundTruth: string }> = [
+		{ planType: "free", expected: "Free", groundTruth: "personal free" },
+		{ planType: "pro", expected: "Pro", groundTruth: "personal $200/mo" },
+		{ planType: "team", expected: "Business", groundTruth: "business seat, 1x allowance" },
+		{
+			planType: "self_serve_business_prolite",
+			expected: "Business Premium",
+			groundTruth: "business seat, premium, 5x allowance",
+		},
+	];
+
+	for (const { planType, expected, groundTruth } of OBSERVED) {
+		it(`maps ${planType} to ${expected} (${groundTruth})`, () => {
+			expect(formatPlanType(planType)).toBe(expected);
+		});
+	}
+
+	it("maps plus to Plus", () => {
+		expect(formatPlanType("plus")).toBe("Plus");
+	});
+
+	it("passes an unrecognized plan type through verbatim rather than guessing", () => {
+		expect(formatPlanType("some_future_plan")).toBe("some_future_plan");
+	});
+});

--- a/test/token-utils.test.ts
+++ b/test/token-utils.test.ts
@@ -14,7 +14,6 @@ import {
 	shouldUpdateAccountIdFromToken,
 	resolveRequestAccountId,
 	sanitizeEmail,
-	formatChatGptAccountLabel,
 	isGeneratedAccountLabel,
 } from "../lib/auth/token-utils.js";
 import { JWT_CLAIM_PATH, JWT_PROFILE_CLAIM_PATH } from "../lib/constants.js";
@@ -1044,47 +1043,6 @@ describe("Token Utils Module", () => {
 		});
 	});
 
-	describe("formatChatGptAccountLabel", () => {
-		it("renders email and the account id suffix", () => {
-			expect(
-				formatChatGptAccountLabel(
-					"oferty@nowaker.net",
-					"2aae3eeb-f7fd-4b2d-96c1-413d33c487c4",
-				),
-			).toBe("oferty@nowaker.net id:c487c4");
-		});
-
-		it("falls back to the id alone when no email is known", () => {
-			expect(
-				formatChatGptAccountLabel(undefined, "2aae3eeb-f7fd-4b2d-96c1-413d33c487c4"),
-			).toBe("id:c487c4");
-		});
-
-		it("falls back to the email alone when no account id is known", () => {
-			expect(formatChatGptAccountLabel("user@example.com", undefined)).toBe(
-				"user@example.com",
-			);
-		});
-
-		it("returns undefined when neither identity is known", () => {
-			expect(formatChatGptAccountLabel(undefined, undefined)).toBeUndefined();
-			expect(formatChatGptAccountLabel("  ", "  ")).toBeUndefined();
-		});
-
-		it("uses a short account id verbatim", () => {
-			expect(formatChatGptAccountLabel("user@example.com", "abc")).toBe(
-				"user@example.com id:abc",
-			);
-		});
-
-		it("keeps two seats of one workspace distinguishable by email", () => {
-			const workspace = "05cd9f04-d56a-4256-9934-9cb827989a40";
-			expect(formatChatGptAccountLabel("oferty@nowaker.net", workspace)).not.toBe(
-				formatChatGptAccountLabel("nowaker@virtkick.com", workspace),
-			);
-		});
-	});
-
 	describe("isGeneratedAccountLabel", () => {
 		// Legacy generated shape: "<api org name> (role:<role>) [id:<suffix>]".
 		it.each([
@@ -1110,6 +1068,44 @@ describe("Token Utils Module", () => {
 		it("treats an absent or blank label as not user supplied", () => {
 			expect(isGeneratedAccountLabel(undefined)).toBe(true);
 			expect(isGeneratedAccountLabel("   ")).toBe(true);
+		});
+
+		// Coupled to the generator on purpose. The classification only does its
+		// job — clearing a stale generated label while keeping a name a user
+		// typed — while it agrees with what the plugin actually emits, and a
+		// generator whose output failed this check would pin its own labels
+		// permanently.
+		it("classifies every label the candidate generator emits as generated", () => {
+			mockedDecodeJWT.mockImplementation((token) => {
+				if (token === "access_token") {
+					return {
+						[JWT_CLAIM_PATH]: {
+							chatgpt_account_id: "2aae3eeb-f7fd-4b2d-96c1-413d33c487c4",
+							organizations: [
+								{
+									id: "org-yRC81tihk0WYRlMQpBEW4A2Q",
+									name: "DreamHost API",
+									role: "owner",
+									is_default: true,
+								},
+							],
+						},
+					};
+				}
+				if (token === "id_token") {
+					return { chatgpt_account_id: "05cd9f04-d56a-4256-9934-9cb827989a40" };
+				}
+				return null;
+			});
+
+			const labels = getAccountIdCandidates("access_token", "id_token")
+				.map((candidate) => candidate.label)
+				.filter((label): label is string => !!label);
+
+			expect(labels.length).toBeGreaterThan(0);
+			for (const label of labels) {
+				expect(isGeneratedAccountLabel(label)).toBe(true);
+			}
 		});
 	});
 });

--- a/test/token-utils.test.ts
+++ b/test/token-utils.test.ts
@@ -14,8 +14,10 @@ import {
 	shouldUpdateAccountIdFromToken,
 	resolveRequestAccountId,
 	sanitizeEmail,
+	formatChatGptAccountLabel,
+	isGeneratedAccountLabel,
 } from "../lib/auth/token-utils.js";
-import { JWT_CLAIM_PATH } from "../lib/constants.js";
+import { JWT_CLAIM_PATH, JWT_PROFILE_CLAIM_PATH } from "../lib/constants.js";
 
 const mockedDecodeJWT = vi.mocked(decodeJWT);
 
@@ -132,6 +134,17 @@ describe("Token Utils Module", () => {
 				},
 			});
 			expect(extractAccountEmail("access_token")).toBe("nested@example.com");
+		});
+
+		it("should extract email from the profile claim when no id_token exists", () => {
+			mockedDecodeJWT.mockReturnValue({
+				[JWT_PROFILE_CLAIM_PATH]: {
+					email: "profile@example.com",
+					email_verified: true,
+					name: "Profile Owner",
+				},
+			});
+			expect(extractAccountEmail("access_token")).toBe("profile@example.com");
 		});
 
 		it("should extract email from chatgpt_user_email field", () => {
@@ -1028,6 +1041,75 @@ describe("Token Utils Module", () => {
 
 		it("should handle mixed case and whitespace", () => {
 			expect(sanitizeEmail("  User@Example.COM  ")).toBe("user@example.com");
+		});
+	});
+
+	describe("formatChatGptAccountLabel", () => {
+		it("renders email and the account id suffix", () => {
+			expect(
+				formatChatGptAccountLabel(
+					"oferty@nowaker.net",
+					"2aae3eeb-f7fd-4b2d-96c1-413d33c487c4",
+				),
+			).toBe("oferty@nowaker.net id:c487c4");
+		});
+
+		it("falls back to the id alone when no email is known", () => {
+			expect(
+				formatChatGptAccountLabel(undefined, "2aae3eeb-f7fd-4b2d-96c1-413d33c487c4"),
+			).toBe("id:c487c4");
+		});
+
+		it("falls back to the email alone when no account id is known", () => {
+			expect(formatChatGptAccountLabel("user@example.com", undefined)).toBe(
+				"user@example.com",
+			);
+		});
+
+		it("returns undefined when neither identity is known", () => {
+			expect(formatChatGptAccountLabel(undefined, undefined)).toBeUndefined();
+			expect(formatChatGptAccountLabel("  ", "  ")).toBeUndefined();
+		});
+
+		it("uses a short account id verbatim", () => {
+			expect(formatChatGptAccountLabel("user@example.com", "abc")).toBe(
+				"user@example.com id:abc",
+			);
+		});
+
+		it("keeps two seats of one workspace distinguishable by email", () => {
+			const workspace = "05cd9f04-d56a-4256-9934-9cb827989a40";
+			expect(formatChatGptAccountLabel("oferty@nowaker.net", workspace)).not.toBe(
+				formatChatGptAccountLabel("nowaker@virtkick.com", workspace),
+			);
+		});
+	});
+
+	describe("isGeneratedAccountLabel", () => {
+		// Legacy generated shape: "<api org name> (role:<role>) [id:<suffix>]".
+		it.each([
+			"DreamHost API (role:owner) [id:c487c4]",
+			"Personal (role:owner) [id:989a40]",
+			"Token account [id:c487c4]",
+			"ID token account [id:c487c4]",
+			"Workspace [id:c487c4]",
+			"Override [id:c487c4]",
+		])("treats %s as machine generated", (label) => {
+			expect(isGeneratedAccountLabel(label)).toBe(true);
+		});
+
+		it.each([
+			"oferty@nowaker.net id:c487c4",
+			"nowaker@virtkick.com id:8830b3",
+			"My work account",
+			"billing [team]",
+		])("treats %s as user supplied", (label) => {
+			expect(isGeneratedAccountLabel(label)).toBe(false);
+		});
+
+		it("treats an absent or blank label as not user supplied", () => {
+			expect(isGeneratedAccountLabel(undefined)).toBe(true);
+			expect(isGeneratedAccountLabel("   ")).toBe(true);
 		});
 	});
 });

--- a/test/tools-codex-list.test.ts
+++ b/test/tools-codex-list.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ToolContext } from "../lib/tools/index.js";
+import type { AccountStorageV3 } from "../lib/storage.js";
+import { createCodexListTool } from "../lib/tools/codex-list.js";
+import { resolveDisplayEmail } from "../lib/account-display.js";
+import { createUiTheme } from "../lib/ui/theme.js";
+
+vi.mock("../lib/storage.js", () => ({
+	loadAccounts: vi.fn(),
+	getStoragePath: vi.fn(() => "/tmp/accounts.json"),
+}));
+
+vi.mock("../lib/accounts.js", async () => {
+	const actual = await vi.importActual<typeof import("../lib/accounts.js")>(
+		"../lib/accounts.js",
+	);
+	return { ...actual, AccountManager: { loadFromDisk: vi.fn(async () => ({})) } };
+});
+
+import { loadAccounts } from "../lib/storage.js";
+
+function formatCommandAccountLabel(
+	account: { email?: string; accountLabel?: string } | undefined,
+	index: number,
+	options: { maskEmail?: boolean } = {},
+): string {
+	const email = resolveDisplayEmail(account?.email, options.maskEmail ?? false);
+	const label = account?.accountLabel?.trim();
+	const details = [label, email].filter(Boolean);
+	if (details.length === 0) return `Account ${index + 1}`;
+	return `Account ${index + 1} (${details.join(", ")})`;
+}
+
+function buildCtx(options: { v2Enabled?: boolean } = {}): ToolContext {
+	const ctx = {
+		resolveUiRuntime: () => ({
+			v2Enabled: options.v2Enabled ?? false,
+			colorProfile: "ansi16",
+			glyphMode: "ascii",
+			theme: createUiTheme({ profile: "ansi16", glyphMode: "ascii" }),
+		}),
+		resolveMaskEmail: () => false,
+		resolveActiveIndex: () => 0,
+		formatCommandAccountLabel,
+		formatRateLimitEntry: () => null,
+		buildJsonAccountIdentity: (
+			index: number,
+			opts: { includeSensitive?: boolean; account?: { email?: string } } = {},
+		) => ({
+			index: index + 1,
+			zeroBasedIndex: index,
+			...(opts.includeSensitive ? { email: opts.account?.email ?? null } : {}),
+		}),
+	};
+	return ctx as unknown as ToolContext;
+}
+
+/** The six real accounts' plan slugs, paired with the tier each one names. */
+const REAL_POOL: AccountStorageV3 = {
+	version: 3,
+	activeIndex: 0,
+	accounts: [
+		{
+			email: "oferty@nowaker.net",
+			accountLabel: "oferty@nowaker.net id:c487c4",
+			planType: "pro",
+			refreshToken: "r1",
+			addedAt: 1,
+			lastUsed: 1,
+		},
+		{
+			email: "nowaker@virtkick.com",
+			accountLabel: "nowaker@virtkick.com id:989a40",
+			planType: "team",
+			refreshToken: "r2",
+			addedAt: 2,
+			lastUsed: 2,
+		},
+		{
+			email: "oferty@nowaker.net",
+			accountLabel: "oferty@nowaker.net id:989a40",
+			planType: "self_serve_business_prolite",
+			refreshToken: "r3",
+			addedAt: 3,
+			lastUsed: 3,
+		},
+		{
+			email: "nowaker@virtkick.com",
+			accountLabel: "nowaker@virtkick.com id:8830b3",
+			planType: "free",
+			refreshToken: "r4",
+			addedAt: 4,
+			lastUsed: 4,
+		},
+	],
+};
+
+describe("codex-list plan tier", () => {
+	beforeEach(() => {
+		vi.mocked(loadAccounts).mockReset();
+	});
+
+	it("names each stored plan slug in the plain table", async () => {
+		vi.mocked(loadAccounts).mockResolvedValue(REAL_POOL);
+
+		const tool = createCodexListTool(buildCtx());
+		const output = (await tool.execute({}, {} as never)) as string;
+
+		expect(output).toContain("Pro");
+		expect(output).toContain("Business");
+		expect(output).toContain("Business Premium");
+		expect(output).toContain("Free");
+	});
+
+	it("reports the plan slug in JSON without requiring includeSensitive", async () => {
+		vi.mocked(loadAccounts).mockResolvedValue(REAL_POOL);
+
+		const tool = createCodexListTool(buildCtx());
+		const parsed = JSON.parse(
+			(await tool.execute({ format: "json" }, {} as never)) as string,
+		) as { accounts: Array<{ planType: string | null; plan: string | null }> };
+
+		expect(parsed.accounts.map((account) => account.planType)).toEqual([
+			"pro",
+			"team",
+			"self_serve_business_prolite",
+			"free",
+		]);
+		expect(parsed.accounts.map((account) => account.plan)).toEqual([
+			"Pro",
+			"Business",
+			"Business Premium",
+			"Free",
+		]);
+	});
+
+	it("reports a null plan for an account stored before plan detection", async () => {
+		vi.mocked(loadAccounts).mockResolvedValue({
+			version: 3,
+			activeIndex: 0,
+			accounts: [
+				{ email: "old@example.com", refreshToken: "r1", addedAt: 1, lastUsed: 1 },
+			],
+		});
+
+		const tool = createCodexListTool(buildCtx());
+		const parsed = JSON.parse(
+			(await tool.execute({ format: "json" }, {} as never)) as string,
+		) as { accounts: Array<{ planType: string | null; plan: string | null }> };
+
+		expect(parsed.accounts[0]?.planType).toBeNull();
+		expect(parsed.accounts[0]?.plan).toBeNull();
+	});
+
+	it("badges the plan in the v2 UI", async () => {
+		vi.mocked(loadAccounts).mockResolvedValue(REAL_POOL);
+
+		const tool = createCodexListTool(buildCtx({ v2Enabled: true }));
+		const output = (await tool.execute({}, {} as never)) as string;
+
+		expect(output).toContain("Business Premium");
+		expect(output).toContain("Pro");
+	});
+});

--- a/test/tools-codex-list.test.ts
+++ b/test/tools-codex-list.test.ts
@@ -63,7 +63,6 @@ const REAL_POOL: AccountStorageV3 = {
 	accounts: [
 		{
 			email: "oferty@nowaker.net",
-			accountLabel: "oferty@nowaker.net id:c487c4",
 			planType: "pro",
 			refreshToken: "r1",
 			addedAt: 1,
@@ -71,7 +70,6 @@ const REAL_POOL: AccountStorageV3 = {
 		},
 		{
 			email: "nowaker@virtkick.com",
-			accountLabel: "nowaker@virtkick.com id:989a40",
 			planType: "team",
 			refreshToken: "r2",
 			addedAt: 2,
@@ -79,7 +77,6 @@ const REAL_POOL: AccountStorageV3 = {
 		},
 		{
 			email: "oferty@nowaker.net",
-			accountLabel: "oferty@nowaker.net id:989a40",
 			planType: "self_serve_business_prolite",
 			refreshToken: "r3",
 			addedAt: 3,
@@ -87,7 +84,6 @@ const REAL_POOL: AccountStorageV3 = {
 		},
 		{
 			email: "nowaker@virtkick.com",
-			accountLabel: "nowaker@virtkick.com id:8830b3",
 			planType: "free",
 			refreshToken: "r4",
 			addedAt: 4,

--- a/test/tui-status.test.ts
+++ b/test/tui-status.test.ts
@@ -220,7 +220,9 @@ describe("TUI prompt status helpers", () => {
 
 		expect(details).toContain("Account: [neil@example.com] (Account 2");
 		expect(details).toContain("5h: 88% left");
-		expect(details).toContain("Plan: plus");
+		// Named the same way the stored plan is, so one seat does not read
+		// "Plus" in codex-list and "plus" here.
+		expect(details).toContain("Plan: Plus");
 		expect(details).toContain("Active limit: 40");
 		expect(details).toContain("Source: response headers");
 		expect(details).toContain("Updated: just now");


### PR DESCRIPTION
## Summary

- What changed?

  An account is now named from its own ChatGPT credential as `<email> id:<last 6 of account id>`, and its ChatGPT plan is detected and shown.

  Previously an account was named after whichever candidate `selectBestAccountCandidate` preferred. With `id_token_add_organizations=true` those candidates are the user's **API-platform organizations**, not their ChatGPT workspaces, so a personal ChatGPT subscription was named after an unrelated API org the user happened to own, e.g. `DreamHost API (role:owner) [id:c487c4]`. Two different ChatGPT workspaces belonging to one login were also stamped with a single `organizationId` that belonged to neither of them.

  A ChatGPT credential carries no workspace name at all. Its access token holds `chatgpt_account_id` (the workspace the backend meters), `chatgpt_account_user_id` (the seat), the signed-in email, and nothing naming the subscription. The label is therefore built from the identity that is actually present, and the organization id is kept as dedupe metadata only.

  Three supporting changes:

  - `extractAccountEmail` now also reads `https://api.openai.com/profile`. That is the only email an access token carries on its own, so without it the address is unrecoverable on a refresh returning no `id_token`, and the label degrades to a bare `id:xxxxxx`.
  - A label set with `codex-label` is preserved; only a generated label is refreshed. Re-logging in repairs a stale API-org label without overwriting a name someone typed.
  - `relabelCandidateForAccountId` is removed. Its only caller was the label derivation this replaces.

  Plan detection reads `chatgpt_plan_type` from the access token, stores it as `planType`, and reports it from `codex-list` (table column, v2 badge, JSON) and `codex-status` (JSON). An unrecognized slug is shown verbatim rather than renamed.

- Why is this needed?

  The label reported the wrong organization and the wrong account type, and carried no plan information. For a user with several ChatGPT subscriptions the list gave no way to tell one account from another, and actively misidentified which organization an account belonged to.

### Evidence

Validated against six real accounts covering four distinct `chatgpt_plan_type` values. For every one, the access-token claim and the `plan_type` returned by the Codex `/wham/usage` endpoint agreed:

| `chatgpt_plan_type` | reported as | actual subscription |
| --- | --- | --- |
| `pro` | Pro | Personal Max 20x |
| `team` | Business | Business Standard 1x |
| `self_serve_business_prolite` | Business Premium | Business premium 5x |
| `free` | Free | Personal Free |

`team` is the slug still emitted for what OpenAI now calls Business, and `self_serve_business_prolite` is the premium Business seat; neither name is derivable from its slug, so both are pinned in the mapping rather than reformatted.

Two limits worth stating plainly:

- The multiplier within a plan (1x / 5x / 20x) is not separately encoded. It follows from the slug for the plans observed here, and no claim in the credential distinguishes it further.
- `plus` and `enterprise` are included in the mapping as the standard OpenAI slugs but were not present in the sample, so they are unvalidated. They map to their own names, so a wrong guess cannot misreport a subscription.

The same six accounts also produced the diagnosis: two ChatGPT workspaces of one login shared one stored `organizationId` that matched neither workspace's own `poid`, which is what identified the API-org leak as the source of the wrong name.

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`

`npm test` passes 3198 tests. One pre-existing failure, `paths.test.ts > rejects lookalike prefix paths outside home directory`, reproduces identically on the base commit and is an artifact of running with a relocated `HOME`; it is unrelated to this change.

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue: none
- Follow-up work or rollout notes:

  This branch is stacked on #242. The first two commits belong to that PR and will drop out of this diff once it merges. They are kept in place deliberately: without #242 the test suite can overwrite a real account pool, so rebasing them away would make running `npm test` on this branch unsafe.

  Existing accounts keep their stored label until the next login, at which point a generated API-org label is replaced and a user-set label is left alone. `planType` is absent for accounts stored before this change and is populated on the next login or refresh; surfaces report it as `unknown` / `null` until then.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account labels now use the ChatGPT email and account ID, while preserving custom labels.
  * Account plan information is detected and stored during login.
  * `codex-list` and `codex-status` now display plan tiers in table, JSON, and UI outputs.
  * Unrecognized plan names are shown as provided.

* **Bug Fixes**
  * Disposing an account manager now cancels pending saves, preventing stale data from overwriting newer account state.

* **Documentation**
  * Added documentation describing account labeling and plan display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this revision derives and reports chatgpt plan metadata, changes generated account identity handling, and adds disposed-manager persistence coordination.

- account plan information is stored and exposed through list, status, and tui surfaces.
- generated labels no longer use api-platform organization candidates.
- concurrent manager replacement now degrades stale saves to a volatile-state merge, but the refresh and masking fixes remain incomplete.

<h3>Confidence Score: 0/5</h3>

this pr is not safe to merge until email masking, refresh-wide plan propagation, and the disposed-manager token rotation race are fixed.

generated labels can still disclose raw email addresses, several refresh paths retain stale plan metadata, and a concurrent manager replacement can drop a newly rotated single-use refresh token.

**Files Needing Attention:** lib/auth/login-runner.ts, lib/auth/token-utils.ts, lib/accounts/state.ts, lib/accounts/persistence.ts

<details open><summary><h3>Security Review</h3></summary>

email masking can still be bypassed by a previously generated label. a cache-replacement concurrency race can also discard a newly rotated single-use refresh token, creating a token safety risk.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/auth/login-runner.ts | generated-label replacement leaves the earlier email-bearing generated shape classified as custom and therefore unmasked. |
| lib/accounts/state.ts | plan extraction is attached to one account-update path while multiple refresh paths bypass it. |
| lib/accounts/persistence.ts | the new concurrency handling preserves membership but can discard credentials and plan metadata from an in-flight refresh. |
| lib/auth/token-utils.ts | the generated-label classifier recognizes bracketed legacy labels but not the branch’s earlier `<email> id:<suffix>` format. |
| test/plan-tier-persistence.test.ts | vitest covers direct `updateFromAuth` persistence but misses proactive, health, hydration, manual, and disposed-manager refresh paths. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant R as in-flight request
  participant O as outgoing manager
  participant N as successor manager
  participant D as account storage
  R->>O: begin token refresh
  N->>D: load current account state
  N->>O: dispose after cache replacement
  R->>O: updateFromAuth(rotated token, plan)
  R->>O: saveToDiskDebounced()
  O->>D: merge only volatile state
  Note over O,D: rotated token and plan are dropped
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
lib/auth/login-runner.ts:843-845
**stale labels bypass email masking**

when an account already stores the generated `<email> id:<suffix>` label, `isGeneratedAccountLabel` classifies it as custom because it lacks the bracketed `[id:…]` suffix. re-login therefore preserves the label, and account output renders the raw email even when `maskEmail` is enabled.

**how this was verified:** the stored label shape fails the generated-label pattern and is then rendered verbatim by the command formatter.

### Issue 2
lib/accounts/state.ts:646-649
**refresh paths retain stale plans**

when a token is renewed through proactive refresh, health checking, hydration, or manual refresh, those paths replace credentials without calling `updateFromAuth`, the only refresh-time extraction of `planType`. `codex-list` and `codex-status` therefore continue reporting the old or unknown plan after a successful refresh.

### Issue 3
lib/accounts/persistence.ts:96-105
**disposed saves drop rotated tokens**

if cache replacement disposes a manager while an in-flight request completes a refresh, `updateFromAuth` installs the rotated token and plan on that outgoing manager, but the subsequent disposed save merges only volatile state. disk retains the consumed single-use refresh token and stale plan, so the next refresh can fail and status remains outdated.

**how this was verified:** the disposed branch routes the save through `mergeVolatileState`, which copies rate limits, cooldowns, and last-used state but not refreshed credentials or `planType`.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(auth): stop the generated label leak..."](https://github.com/ndycode/oc-codex-multi-auth/commit/ee0f19eb84420e9f5a852e0a0cb1b03c3fe861de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59353064)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->