### PR TITLE
fix(reasoning): case-fold effort and coerce unknown tokens

### DIFF
--- a/lib/request/request-transformer.ts
+++ b/lib/request/request-transformer.ts
@@ -16,7 +16,11 @@ import {
 	GPT_6_ASTRA_MODEL_ID,
 	getNormalizedModel,
 } from "./helpers/model-map.js";
-import { getEffortSuffix, stripEffortSuffix } from "./helpers/effort-suffix.js";
+import {
+	EFFORT_SUFFIXES,
+	getEffortSuffix,
+	stripEffortSuffix,
+} from "./helpers/effort-suffix.js";
 import {
 	filterOpenCodeSystemPromptsWithCachedPrompt,
 	normalizeOrphanedToolOutputs,
@@ -689,9 +693,18 @@ export function getReasoningConfig(
 				? "minimal"
 				: "medium";
 
-	// Get user-requested effort
-	let effort = userConfig.reasoningEffort || defaultEffort;
-	const originalRequestedEffort = userConfig.reasoningEffort ?? defaultEffort;
+	// Get user-requested effort.
+	//
+	// Case-fold first. Every clamp below compares against lowercase literals, so
+	// an effort that arrives capitalized matched none of them and went to the
+	// wire unclamped: `"ULTRA"` stayed `ULTRA` instead of collapsing to `max`,
+	// `"NONE"` reached models that reject `none`, and `"MAX"` reached families
+	// that top out at `high`. `reasoningEffort` is read straight off
+	// opencode.json, so its TypeScript union does not constrain it at runtime.
+	// `sanitizeReasoningSummary` already case-folds the sibling field.
+	const requestedEffort = sanitizeReasoningEffort(userConfig.reasoningEffort);
+	let effort = requestedEffort || defaultEffort;
+	const originalRequestedEffort = requestedEffort ?? defaultEffort;
 
 	if (isCodexMini) {
 		if (effort === "minimal" || effort === "low" || effort === "none") {
@@ -763,12 +776,43 @@ export function getReasoningConfig(
 		effort = "low";
 	}
 
+	// Anything still unrecognized here is a token no family clamp matched, so it
+	// would go to the wire verbatim and come back a 400. `gpt-5-codex-mini` has
+	// always coerced these to its default through its own catch-all (pinned by
+	// "should clamp codex-mini unknown effort to medium"); every other family
+	// lacked one. Coerce the same way rather than emitting the unknown token.
+	if (!KNOWN_REASONING_EFFORTS.has(effort as string)) {
+		logWarn(
+			`unknown reasoning effort '${originalRequestedEffort}'; using '${defaultEffort}'`,
+		);
+		effort = defaultEffort;
+	}
+
 	const summary = sanitizeReasoningSummary(userConfig.reasoningSummary);
 
 	return {
 		effort,
 		summary,
 	};
+}
+
+/** Effort tokens this plugin recognizes, shared with the model-id suffix parser. */
+const KNOWN_REASONING_EFFORTS: ReadonlySet<string> = new Set(EFFORT_SUFFIXES);
+
+/**
+ * Case-fold a configured reasoning effort so the family clamps can see it.
+ *
+ * Deliberately does not reject unknown values: an effort this plugin does not
+ * recognize may be one the backend has added, and the clamps below already
+ * floor the ones each family refuses. Only the casing is normalized.
+ */
+function sanitizeReasoningEffort(
+	effort: ConfigOptions["reasoningEffort"],
+): ConfigOptions["reasoningEffort"] {
+	if (typeof effort !== "string") return effort;
+	const trimmed = effort.trim();
+	if (!trimmed) return undefined;
+	return trimmed.toLowerCase() as ConfigOptions["reasoningEffort"];
 }
 
 function sanitizeReasoningSummary(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -165,6 +165,66 @@ describe('Configuration Parsing', () => {
 			});
 			expect(unknown.effort).toBe('medium');
 		});
+
+		// `reasoningEffort` is read straight off opencode.json, so its TypeScript
+		// union does not constrain it at runtime. Every clamp compares against
+		// lowercase literals, so a capitalized value matched none of them and
+		// went to the wire unclamped.
+		describe('effort case-folding', () => {
+			it('case-folds before clamping, so no capitalized effort escapes', () => {
+				// ultra is a client-side tier and must never reach the backend.
+				expect(
+					getReasoningConfig('gpt-6-astra', { reasoningEffort: 'ULTRA' as never }).effort,
+				).toBe('max');
+				// astra rejects "none".
+				expect(
+					getReasoningConfig('gpt-6-astra', { reasoningEffort: 'NONE' as never }).effort,
+				).toBe('low');
+				// Codex families reject "minimal".
+				expect(
+					getReasoningConfig('gpt-5-codex', { reasoningEffort: 'MINIMAL' as never }).effort,
+				).toBe('low');
+				// gpt-5.1 tops out at high.
+				expect(
+					getReasoningConfig('gpt-5.1', { reasoningEffort: 'MAX' as never }).effort,
+				).toBe('high');
+			});
+
+			it('trims surrounding whitespace', () => {
+				expect(
+					getReasoningConfig('gpt-6-astra', { reasoningEffort: '  MAX  ' as never }).effort,
+				).toBe('max');
+				expect(
+					getReasoningConfig('gpt-6-astra', { reasoningEffort: '   ' as never }).effort,
+				).toBeTruthy();
+			});
+
+			it('leaves already-lowercase efforts exactly as they were', () => {
+				expect(
+					getReasoningConfig('gpt-6-astra', { reasoningEffort: 'xhigh' }).effort,
+				).toBe('xhigh');
+				expect(
+					getReasoningConfig('gpt-5.6-sol', { reasoningEffort: 'max' }).effort,
+				).toBe('max');
+				expect(
+					getReasoningConfig('gpt-5.5', { reasoningEffort: 'none' }).effort,
+				).toBe('none');
+			});
+		});
+
+		// Only codex-mini used to coerce these; every other family emitted the
+		// unknown token verbatim, which the backend answers with a 400.
+		it('coerces an unknown effort to the family default, not just for codex-mini', () => {
+			for (const model of ['gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.5', 'gpt-5-codex', 'gpt-5.1']) {
+				const resolved = getReasoningConfig(model, {
+					reasoningEffort: 'invalid-effort' as never,
+				}).effort;
+				expect(
+					['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
+					`${model} emitted ${resolved}`,
+				).toContain(resolved);
+			}
+		});
 	});
 
 	describe('Model-specific behavior', () => {


### PR DESCRIPTION
Found by a release stress probe on merged main, before cutting 6.17.0. Two ways a reasoning effort reaches the wire without passing a single family clamp. Both are pre-existing, not from #246.

## 1. A capitalized effort bypasses every clamp

Every clamp in `getReasoningConfig` compares against lowercase literals, but `reasoningEffort` is read straight off `opencode.json`, where its TypeScript union constrains nothing at runtime. Measured against the built `dist/` before the fix:

| input | emitted | should be | why it matters |
|---|---|---|---|
| `gpt-6-astra` + `"ULTRA"` | `ULTRA` | `max` | `ultra` is a Codex client-side tier and must never reach the backend |
| `gpt-6-astra` + `"NONE"` | `NONE` | `low` | Astra rejects `none` |
| `gpt-5-codex` + `"MINIMAL"` | `MINIMAL` | `low` | Codex families reject `minimal` |
| `gpt-5.1` + `"MAX"` | `MAX` | `high` | 5.1 tops out at `high` |

Lowercase spellings of all four already clamped correctly, so this is purely the casing. Affects every family equally, including `gpt-5.1` and `gpt-5.2`, which long predate the GPT-6 work.

`sanitizeReasoningSummary` already case-folds the sibling field. Effort was simply missed.

## 2. An unknown token ships verbatim

An effort the plugin does not recognize survived every clamp and went out as-is, so a typo produced a backend 400 instead of a working request.

`gpt-5-codex-mini` never had this problem: its branch ends in a catch-all, pinned by the existing test `should clamp codex-mini unknown effort to medium`. No other family had one. Unknown tokens now fall back to that family's default effort and log a warning.

I checked whether the passthrough was deliberate before changing it. Two precedents in the same file say it was not: the codex-mini test above, and `sanitizeReasoningSummary` coercing an unrecognized summary to `auto`. There is no precedent of deliberately forwarding an unenumerated effort. When `max` and `ultra` arrived with GPT-5.6 they were added by explicit enumeration (commit 1937693), so the plugin does not rely on forwarding unknowns.

Case-folding does not itself reject unrecognized values. The coercion is a separate, later step, so the two behaviours stay independently readable.

## Verification

- `npx tsc --noEmit` clean, `npm run lint` clean, `npm run build` clean
- `npx vitest run` — **3288 passed**, 2 skipped
- Regression tests live in `test/config.test.ts` beside the codex-mini case they generalize. **Verified they fail without this change**: 3 failures covering capitalization (`expected 'ULTRA' to be 'max'`), whitespace (`expected '  MAX  ' to be 'max'`), and the unknown token (`gpt-6-astra emitted invalid-effort`).

## Risk

Behaviour changes only for inputs that previously produced a backend 400. Anyone relying on forwarding an unenumerated-but-valid effort would now get the family default instead; I found no such effort in the current Codex catalog, which enumerates `low` through `ultra`, all of which the plugin already knows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDBtUDSJgUp5PaRYMHhT3V


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reasoning effort settings now recognize uppercase and whitespace-padded values correctly.
  * Invalid reasoning effort values are safely replaced with the model family’s default instead of causing request errors.
  * Reasoning effort limits are applied consistently across supported model families.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr normalizes configured reasoning efforts before applying model-family clamps and replaces unknown tokens with safe family defaults.

- trims and lowercases runtime configuration values.
- prevents unsupported or client-only efforts from reaching the upstream wire.
- adds vitest regressions for capitalization, whitespace, and unknown tokens, although two assertions do not pin exact defaults.
- no windows filesystem, token safety, or concurrency behavior changes are present.

<h3>Confidence Score: 4/5</h3>

the implementation appears safe to merge; strengthening the new vitest assertions is a non-blocking improvement.

no behavioral failure remains in the normalization or fallback logic, but two regression tests can pass when a wrong yet recognized effort is selected.

**Files Needing Attention:** test/config.test.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/request/request-transformer.ts | normalizes runtime effort strings and safely coerces unknown values after family-specific clamping. |
| test/config.test.ts | adds relevant vitest coverage, but the unknown-token and whitespace-only assertions are too broad to guard exact fallback behavior. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    input[configured effort] --> normalize[trim and lowercase]
    normalize --> clamp[apply model-family clamps]
    clamp --> known{recognized token?}
    known -->|yes| wire[emit effort]
    known -->|no| fallback[use family default]
    fallback --> wire
```
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Freasoning-effort-normalization%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Freasoning-effort-normalization%22.%0A%0AGreploop%20ndycode%2Foc-codex-multi-auth%20PR%20%23247%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=ndycode%2Foc-codex-multi-auth&pr=247&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Freasoning-effort-normalization%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Freasoning-effort-normalization%22.%0A%0A%23%23%23%20Issue%201%0Atest%2Fconfig.test.ts%3A222-225%0A**assert%20exact%20effort%20defaults**%0A%0Athese%20vitest%20cases%20do%20not%20verify%20the%20behavior%20they%20describe.%20the%20unknown-token%20case%20accepts%20any%20known%20effort%20instead%20of%20each%20model's%20family%20default%2C%20while%20the%20whitespace-only%20case%20accepts%20any%20truthy%20result.%20incorrect%20mappings%20such%20as%20%60gpt-5.1%60%20falling%20back%20to%20%60high%60%20would%20therefore%20pass.%20assert%20the%20exact%20expected%20effort%20for%20every%20model%20and%20for%20whitespace-only%20input.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ndycode%2Foc-codex-multi-auth&pr=247&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/config.test.ts:222-225
**assert exact effort defaults**

these vitest cases do not verify the behavior they describe. the unknown-token case accepts any known effort instead of each model's family default, while the whitespace-only case accepts any truthy result. incorrect mappings such as `gpt-5.1` falling back to `high` would therefore pass. assert the exact expected effort for every model and for whitespace-only input.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(reasoning): case-fold effort and coe..."](https://github.com/ndycode/oc-codex-multi-auth/commit/b65a5d275e346686daf4d63965237dc0c7068767) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60158514)</sub>

**Context used:**

- Knowledge Base — [Request and response transformation](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/request-transformation.md)

<!-- /greptile_comment -->