### PR TITLE
fix(request): stop prototype keys throwing in the fallback chain

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -892,7 +892,11 @@ export function getUnsupportedCodexFallbackChain(
 		return stripEffortSuffix(stripped);
 	};
 
-	const normalized: Record<string, string[]> = {};
+	// Null-prototype: the keys come from settings.json, which reaches here via
+	// `JSON.parse`, and a parsed `__proto__` key IS a real own property (unlike
+	// one written as an object literal). On a plain object it would reassign
+	// this object's prototype rather than add a row.
+	const normalized: Record<string, string[]> = Object.create(null);
 	for (const [key, value] of Object.entries(chain)) {
 		if (typeof key !== "string" || !Array.isArray(value)) continue;
 		const normalizedKey = normalizeModel(key);

--- a/lib/request/fetch-helpers.ts
+++ b/lib/request/fetch-helpers.ts
@@ -310,7 +310,11 @@ function canonicalizeModelName(model: string | undefined): string | undefined {
 function normalizeFallbackChain(
 	customChain: Record<string, string[]> | undefined,
 ): Record<string, string[]> {
-	const normalized: Record<string, string[]> = {};
+	// Null-prototype: both the keys written here and the keys read out of it are
+	// caller-controlled. A `customChain` entry named `__proto__` reassigns a
+	// plain object's prototype instead of adding a row, and a lookup for
+	// `constructor` returns an inherited member rather than `undefined`.
+	const normalized: Record<string, string[]> = Object.create(null);
 	for (const [key, values] of Object.entries(DEFAULT_UNSUPPORTED_CODEX_FALLBACK_CHAIN)) {
 		const normalizedKey = canonicalizeModelName(key);
 		if (!normalizedKey) continue;
@@ -442,7 +446,14 @@ export function resolveUnsupportedCodexFallbackModel(
 
 	const chain = normalizeFallbackChain(options.customChain);
 	const targets = chain[currentModel] ?? [];
-	if (targets.length === 0) return undefined;
+	// `Array.isArray`, not just a length check. `currentModel` comes from the
+	// caller's `body.model`, so it can be any `Object.prototype` member name. On
+	// a plain object `chain["constructor"]` returns the Object constructor: a
+	// truthy non-array whose `.length` is 1, so an emptiness check passes it
+	// through and the `for...of` below throws `targets is not iterable` inside
+	// the request path. The chain is null-prototype now as well; this guard also
+	// covers a `customChain` value that is not an array.
+	if (!Array.isArray(targets) || targets.length === 0) return undefined;
 
 	for (const target of targets) {
 		if (!options.fallbackToGpt52OnUnsupportedGpt53 &&

--- a/test/prototype-key-safety.test.ts
+++ b/test/prototype-key-safety.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { resolveUnsupportedCodexFallbackModel } from "../lib/request/fetch-helpers.js";
+import { getUnsupportedCodexFallbackChain } from "../lib/config.js";
+
+/**
+ * Model ids reach the fallback chain raw from the caller: the proxy copies
+ * `body.model` verbatim. So the string indexing this plain object can be any
+ * `Object.prototype` member name, and a bare index returns that member rather
+ * than `undefined`. It is truthy and has a `.length`, so the emptiness check
+ * passes it through.
+ *
+ * Found by porting a release-gate stress probe from the sibling repo, where the
+ * same defect was fixed. Both cases below failed before this change.
+ */
+const PROTOTYPE_KEYS = [
+	"constructor",
+	"__proto__",
+	"toString",
+	"valueOf",
+	"hasOwnProperty",
+	"isPrototypeOf",
+	"propertyIsEnumerable",
+	"toLocaleString",
+];
+
+describe("prototype keys cannot masquerade as model ids", () => {
+	const unsupportedBody = {
+		error: {
+			message: "model is not supported when using codex with a chatgpt account",
+		},
+	};
+
+	it("resolves no fallback instead of throwing `targets is not iterable`", () => {
+		for (const key of PROTOTYPE_KEYS) {
+			const resolve = () =>
+				resolveUnsupportedCodexFallbackModel({
+					requestedModel: key,
+					errorBody: unsupportedBody,
+					fallbackOnUnsupportedCodexModel: true,
+					fallbackToGpt52OnUnsupportedGpt53: true,
+				});
+
+			expect(resolve, key).not.toThrow();
+			expect(resolve(), key).toBeUndefined();
+		}
+	});
+
+	it("survives a custom chain carrying a non-array value", () => {
+		expect(() =>
+			resolveUnsupportedCodexFallbackModel({
+				requestedModel: "gpt-5.5",
+				errorBody: unsupportedBody,
+				fallbackOnUnsupportedCodexModel: true,
+				fallbackToGpt52OnUnsupportedGpt53: true,
+				customChain: { "gpt-5.5": "gpt-5.4" } as unknown as Record<
+					string,
+					string[]
+				>,
+			}),
+		).not.toThrow();
+	});
+
+	it("does not let a `__proto__` config key reassign the returned prototype", () => {
+		// JSON.parse, deliberately, not an object literal. A literal `__proto__:`
+		// key sets THAT literal's prototype and never becomes an own property, so
+		// `Object.entries` in the function under test would not see it and this
+		// case would pass with or without the fix. settings.json reaches the
+		// function through JSON.parse, which does create a real own property.
+		const chain = getUnsupportedCodexFallbackChain({
+			unsupportedCodexFallbackChain: JSON.parse(
+				'{"__proto__": ["gpt-5.4"], "gpt-5.5": ["gpt-5.4"]}',
+			),
+		} as never);
+
+		expect(Array.isArray(Object.getPrototypeOf(chain))).toBe(false);
+		expect(chain["gpt-5.5"]).toEqual(["gpt-5.4"]);
+		// Nothing inherited leaks through as a row.
+		expect(chain["toString"]).toBeUndefined();
+	});
+});


### PR DESCRIPTION
fix(request): stop prototype keys throwing in the fallback chain

Ported from the sibling repo, where the same defect was found by a release-gate
stress probe. Both cases below were reproduced against this repo before the fix.

**`resolveUnsupportedCodexFallbackModel` threw inside the request path.**
`currentModel` comes from the caller's `body.model`, so it can be any
`Object.prototype` member name. On a plain object `chain["constructor"]` returns
the Object constructor: truthy, and its `.length` is 1, so `targets.length === 0`
was false and `for (const target of targets)` raised
`TypeError: targets is not iterable`. Reproduced for `constructor`, `toString`,
`valueOf` and `hasOwnProperty`.

**A `__proto__` key in settings.json reassigned an object's prototype.**
`normalizeFallbackChain` and `getUnsupportedCodexFallbackChain` both built a
plain `{}` and copied caller-controlled keys into it. Both are now
`Object.create(null)`, plus an `Array.isArray` guard at the read site for a
`customChain` value that is not an array.

Worth noting for the test: the `__proto__` case has to build its input with
`JSON.parse`, not an object literal. A literal `__proto__:` key sets THAT
literal's prototype and never becomes an own property, so `Object.entries` in
the function under test would not see it and the assertion would hold with or
without the fix. settings.json arrives through `JSON.parse`, which does create a
real own property.

Observed but deliberately NOT changed, because neither crashes and both are
narrower than they look:

- `lib/config.ts` model pools write `pools[normalizedModel]`, so a pool keyed
  `__proto__` would be silently dropped rather than stored. Reads are safe: they
  go through `Object.keys(pools).filter(...)` first, so only own properties are
  ever indexed.
- `lib/accounts/rate-limits.ts` `isRateLimitedForQuotaKey` indexes
  `rateLimitResetTimes[key]`. A prototype key yields a function, and
  `nowMs() < fn` is false rather than a throw, so the account reads as not rate
  limited. `clearExpiredRateLimits` is safe for the same `Object.keys` reason.

Both need a model or quota key literally named after a prototype member, and
neither produces an error. Raising them here would widen a targeted fix.

Verified: full suite 3299 passed, 2 skipped, 0 failed. `npm run typecheck` and
`npm run build` clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ajbw5bo5Wmd1KC81eAKYzg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback-model resolution for model IDs matching special object property names.
  * Prevented malformed or custom fallback chains from causing request errors.
  * Ensured fallback settings handle `__proto__`, `constructor`, and similar keys safely.

* **Tests**
  * Added regression coverage for prototype-key handling and invalid fallback-chain entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr hardens unsupported-model fallback maps against prototype-key collisions and prototype reassignment.

- uses null-prototype maps for configuration and request normalization.
- rejects non-array fallback targets at the lookup boundary.
- adds vitest regression coverage for caller-controlled prototype keys and json-parsed `__proto__`.
- does not affect windows filesystem handling, token safety, or concurrent state.

<h3>Confidence Score: 4/5</h3>

the pr appears safe to merge, with one non-blocking vitest coverage gap.

the prototype-key fixes are correct for identified callers and preserve fallback behavior; only the defensive non-array lookup branch lacks direct regression coverage.

**Files Needing Attention:** test/prototype-key-safety.test.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/config.ts | safely normalizes settings-derived fallback chains into a null-prototype map. |
| lib/request/fetch-helpers.ts | prevents inherited prototype members from becoming fallback targets and defensively checks target arrays. |
| test/prototype-key-safety.test.ts | covers the reproduced prototype-key defects, but its malformed-value case does not reach the new array guard. |

</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fprototype-key-safety%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fprototype-key-safety%22.%0A%0AGreploop%20ndycode%2Foc-codex-multi-auth%20PR%20%23250%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=ndycode%2Foc-codex-multi-auth&pr=250&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ndycode%2Foc-codex-multi-auth%22%20on%20the%20existing%20branch%20%22fix%2Fprototype-key-safety%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fprototype-key-safety%22.%0A%0A%23%23%23%20Issue%201%0Atest%2Fprototype-key-safety.test.ts%3A50-61%0A**array%20guard%20lacks%20coverage**%0A%0Athis%20malformed%20custom-chain%20test%20does%20not%20exercise%20the%20new%20%60array.isarray%28targets%29%60%20branch.%20%60normalizefallbackchain%60%20already%20rejects%20non-array%20values%20before%20lookup%2C%20so%20the%20test%20passes%20both%20before%20and%20after%20this%20pr.%20add%20coverage%20that%20reaches%20the%20guard%2C%20or%20remove%20the%20redundant%20guard%20and%20its%20unsupported%20coverage%20claim%2C%20so%20future%20regressions%20in%20this%20safety%20boundary%20are%20detectable.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ndycode%2Foc-codex-multi-auth&pr=250&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/prototype-key-safety.test.ts:50-61
**array guard lacks coverage**

this malformed custom-chain test does not exercise the new `array.isarray(targets)` branch. `normalizefallbackchain` already rejects non-array values before lookup, so the test passes both before and after this pr. add coverage that reaches the guard, or remove the redundant guard and its unsupported coverage claim, so future regressions in this safety boundary are detectable.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(request): stop prototype keys throwi..."](https://github.com/ndycode/oc-codex-multi-auth/commit/191a2e0509f3013df367d7ba4a96b84881442579) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60203154)</sub>

**Context used:**

- Knowledge Base — [Runtime configuration and model compatibility](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/runtime-configuration-and-models.md)

<!-- /greptile_comment -->