### PR TITLE
feat(tui): use the shared partial email mask in the status line

### DIFF
--- a/lib/tui-status.ts
+++ b/lib/tui-status.ts
@@ -215,7 +215,10 @@ function formatAccountEmail(
 ): string | undefined {
 	const trimmed = email?.trim() || undefined;
 	if (!trimmed) return undefined;
-	const display = maskEmail ? maskEmailsInText(trimmed, true) : trimmed;
+	if (!maskEmail) return `[${trimmed}]`;
+	const display = EMAIL_PATTERN.test(trimmed)
+		? maskEmailsInText(trimmed, true)
+		: (maskEmailForDisplay(trimmed) ?? MASKED_EMAIL);
 	return display ? `[${display}]` : undefined;
 }
 

--- a/lib/tui-status.ts
+++ b/lib/tui-status.ts
@@ -1,4 +1,5 @@
 import type { Config } from "@opencode-ai/sdk/v2";
+import { maskEmailForDisplay } from "./account-display.js";
 import { getEffortSuffix } from "./request/helpers/effort-suffix.js";
 import { formatPlanType } from "./auth/plan-tier.js";
 
@@ -213,7 +214,9 @@ function formatAccountEmail(
 	maskEmail: boolean,
 ): string | undefined {
 	const trimmed = email?.trim() || undefined;
-	return trimmed ? `[${maskEmail ? MASKED_EMAIL : trimmed}]` : undefined;
+	if (!trimmed) return undefined;
+	const display = maskEmail ? maskEmailForDisplay(trimmed) : trimmed;
+	return display ? `[${display}]` : undefined;
 }
 
 function maskEmailsInText(
@@ -221,7 +224,10 @@ function maskEmailsInText(
 	maskEmail: boolean,
 ): string | undefined {
 	if (!value) return undefined;
-	return maskEmail ? value.replace(EMAIL_PATTERN_GLOBAL, MASKED_EMAIL) : value;
+	if (!maskEmail) return value;
+	return value.replace(EMAIL_PATTERN_GLOBAL, (match) =>
+		maskEmailForDisplay(match) ?? MASKED_EMAIL,
+	);
 }
 
 function formatQuotaLimit(

--- a/lib/tui-status.ts
+++ b/lib/tui-status.ts
@@ -69,8 +69,8 @@ const STATUS_SEPARATOR = ` ${String.fromCharCode(183)} `;
 const WARNING_LIMIT_LEFT_PERCENT = 25;
 const DANGER_LIMIT_LEFT_PERCENT = 10;
 const MASKED_EMAIL = "*****";
-const EMAIL_PATTERN = /[^\s(),<>]+@[^\s(),<>]+/;
-const EMAIL_PATTERN_GLOBAL = /[^\s(),<>]+@[^\s(),<>]+/g;
+const EMAIL_PATTERN = /[^\s(),<>,;]+@[^\s(),<>,;]+/;
+const EMAIL_PATTERN_GLOBAL = /[^\s(),<>,;]+@[^\s(),<>,;]+/g;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -215,7 +215,7 @@ function formatAccountEmail(
 ): string | undefined {
 	const trimmed = email?.trim() || undefined;
 	if (!trimmed) return undefined;
-	const display = maskEmail ? maskEmailForDisplay(trimmed) : trimmed;
+	const display = maskEmail ? maskEmailsInText(trimmed, true) : trimmed;
 	return display ? `[${display}]` : undefined;
 }
 

--- a/lib/tui-status.ts
+++ b/lib/tui-status.ts
@@ -69,8 +69,11 @@ const STATUS_SEPARATOR = ` ${String.fromCharCode(183)} `;
 const WARNING_LIMIT_LEFT_PERCENT = 25;
 const DANGER_LIMIT_LEFT_PERCENT = 10;
 const MASKED_EMAIL = "*****";
-const EMAIL_PATTERN = /[^\s(),<>,;]+@[^\s(),<>,;]+/;
-const EMAIL_PATTERN_GLOBAL = /[^\s(),<>,;]+@[^\s(),<>,;]+/g;
+const FLAT_MASKED_HINT = `[${MASKED_EMAIL}]`;
+// Whitespace, brackets, `,` and `;` end a token: none can appear in an
+// address, and all of them separate one address from the next in a label.
+const EMAIL_PATTERN = /[^\s(),<>;]+@[^\s(),<>;]+/;
+const TEXT_TOKEN_GLOBAL = /[^\s(),<>;]+/g;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -209,6 +212,35 @@ function extractEmailFromLabel(label: string | undefined): string | undefined {
 	return match?.[0];
 }
 
+/**
+ * Mask one token that carries an `@`.
+ *
+ * `maskEmailForDisplay` preserves everything from the first `@` onward, which
+ * is the right trade for a single address - `ne***@example.com` names an
+ * account without disclosing it - and the wrong one for a token holding two.
+ * `alice@example.com/bob@corp.com` is a single token, because `/` is not a
+ * separator anything here splits on, and the tail preserved would be the
+ * whole second address. A token carrying more than one `@` is therefore
+ * flattened, since no part of it is known to be safe to keep.
+ */
+function maskEmailToken(token: string): string {
+	const first = token.indexOf("@");
+	if (first <= 0) return MASKED_EMAIL;
+	if (token.indexOf("@", first + 1) !== -1) return MASKED_EMAIL;
+	return maskEmailForDisplay(token) ?? MASKED_EMAIL;
+}
+
+/**
+ * Render the bracketed account hint.
+ *
+ * With masking on, a value containing an address becomes that address masked,
+ * rather than having the address substituted inside the value. What reaches
+ * here is free text - `accountEmail` is whatever the snapshot on disk holds -
+ * and preserving what surrounds an address preserves exactly the identifying
+ * text masking exists to remove: substituting in place would render "Neil
+ * Smith neil@example.com" as "Neil Smith ne***@example.com". A value with no
+ * address in it flattens for the same reason.
+ */
 function formatAccountEmail(
 	email: string | undefined,
 	maskEmail: boolean,
@@ -216,20 +248,29 @@ function formatAccountEmail(
 	const trimmed = email?.trim() || undefined;
 	if (!trimmed) return undefined;
 	if (!maskEmail) return `[${trimmed}]`;
-	const display = EMAIL_PATTERN.test(trimmed)
-		? maskEmailsInText(trimmed, true)
-		: (maskEmailForDisplay(trimmed) ?? MASKED_EMAIL);
-	return display ? `[${display}]` : undefined;
+	const address = extractEmailFromLabel(trimmed);
+	return `[${address ? maskEmailToken(address) : MASKED_EMAIL}]`;
 }
 
+/**
+ * Mask every address in text whose surrounding structure is worth keeping.
+ *
+ * Unlike the hint above, this is used on the account label in the details
+ * dialog, where "Account 2 (…)" is the structure that makes the line
+ * readable. It walks tokens rather than address matches: a match can span two
+ * addresses joined by punctuation the address class does not exclude, and
+ * replacing that match with a partial mask leaves the second address intact.
+ * Every token holding an `@` is masked, so no address survives whatever joins
+ * them.
+ */
 function maskEmailsInText(
 	value: string | undefined,
 	maskEmail: boolean,
 ): string | undefined {
 	if (!value) return undefined;
 	if (!maskEmail) return value;
-	return value.replace(EMAIL_PATTERN_GLOBAL, (match) =>
-		maskEmailForDisplay(match) ?? MASKED_EMAIL,
+	return value.replace(TEXT_TOKEN_GLOBAL, (token) =>
+		token.includes("@") ? maskEmailToken(token) : token,
 	);
 }
 
@@ -246,29 +287,44 @@ function formatQuotaLimit(
 	return reset ? `${base} resets ${reset}` : base;
 }
 
-function formatAccountHint(
+/**
+ * The account hint, longest form first.
+ *
+ * A masked partial hint is about twelve characters longer than the flat
+ * `[*****]` it replaced, and the candidate ladder drops the account hint
+ * entirely when a rung does not fit. Offering the flat form as a second try
+ * at the same rung is what stops turning masking on from removing the account
+ * from a 78- or 96-column status line, which would identify the account less
+ * rather than more.
+ */
+function formatAccountHints(
 	quota: CompactQuotaStatus,
 	maskEmail = false,
-): string | undefined {
-	if (quota.type !== "ready") return undefined;
+): string[] {
+	if (quota.type !== "ready") return [];
 	if (
 		typeof quota.accountIndex !== "number" ||
 		!Number.isFinite(quota.accountIndex)
 	) {
-		return undefined;
+		return [];
 	}
 	if (
 		typeof quota.accountCount === "number" &&
 		Number.isFinite(quota.accountCount) &&
 		quota.accountCount <= 1
 	) {
-		return undefined;
+		return [];
 	}
 	const email =
 		formatAccountEmail(quota.accountEmail, maskEmail) ??
 		formatAccountEmail(extractEmailFromLabel(quota.accountLabel), maskEmail);
-	if (email) return email;
-	return `A${quota.accountIndex}`;
+	if (!email) return [`A${quota.accountIndex}`];
+	// Only when masking is on: the flat form is a mask, and offering it as a
+	// narrow-width fallback with masking off would print `*****` for someone
+	// who asked to see the address.
+	return maskEmail && email !== FLAT_MASKED_HINT
+		? [email, FLAT_MASKED_HINT]
+		: [email];
 }
 
 function findResetLimitForStatus(
@@ -326,7 +382,7 @@ export function formatPromptStatusText(params: {
 	maskEmail?: boolean;
 }): string {
 	const variant = params.variant;
-	const account = formatAccountHint(params.quota, params.maskEmail);
+	const accountForms = formatAccountHints(params.quota, params.maskEmail);
 	const quotaParts = formatQuotaParts(params.quota, true);
 	const quotaPartsWithoutReset = formatQuotaParts(params.quota, false);
 	const quota = quotaParts.length > 0
@@ -337,19 +393,25 @@ export function formatPromptStatusText(params: {
 		? quotaPartsWithoutReset.join(STATUS_SEPARATOR)
 		: quota;
 	const primaryQuotaWithoutReset = quotaPartsWithoutReset[0] ?? primaryQuota;
+	// Each account-bearing rung tries every hint form before the ladder gives
+	// up on showing the account at all.
+	const withAccount = (rest: string | undefined, prefix?: string) =>
+		accountForms.map((form) =>
+			[prefix, form, rest].filter(Boolean).join(STATUS_SEPARATOR),
+		);
 	const candidates = [
-		[account, quota].filter(Boolean).join(STATUS_SEPARATOR),
-		[account, primaryQuota].filter(Boolean).join(STATUS_SEPARATOR),
+		...withAccount(quota),
+		...withAccount(primaryQuota),
 		quota,
 		primaryQuota,
-		[account, quotaWithoutReset].filter(Boolean).join(STATUS_SEPARATOR),
-		[account, primaryQuotaWithoutReset].filter(Boolean).join(STATUS_SEPARATOR),
+		...withAccount(quotaWithoutReset),
+		...withAccount(primaryQuotaWithoutReset),
 		quotaWithoutReset,
 		primaryQuotaWithoutReset,
-		[variant, account, quota].filter(Boolean).join(STATUS_SEPARATOR),
+		...withAccount(quota, variant),
 		[variant, quota].filter(Boolean).join(STATUS_SEPARATOR),
 		variant,
-		account,
+		...accountForms,
 	].filter((candidate): candidate is string => Boolean(candidate));
 	const maxChars = maxStatusChars(params.width);
 	return candidates.find((candidate) => candidate.length <= maxChars) ?? "";
@@ -448,7 +510,8 @@ export function formatQuotaDetailsText(
 	if (quota.type === "unavailable") return "Quota is unavailable.";
 
 	const lines: string[] = [];
-	const accountHint = formatAccountHint(quota, options.maskEmail);
+	// The dialog has a full line to itself, so it always takes the longest form.
+	const accountHint = formatAccountHints(quota, options.maskEmail)[0];
 	const accountLabel = maskEmailsInText(quota.accountLabel, Boolean(options.maskEmail));
 	if (accountLabel && accountHint) {
 		lines.push(`Account: ${accountHint} (${accountLabel})`);

--- a/test/tui-status.test.ts
+++ b/test/tui-status.test.ts
@@ -117,7 +117,7 @@ describe("TUI prompt status helpers", () => {
 				width: 120,
 				maskEmail: true,
 			}),
-		).toBe(`[*****]${sep}5h 88%${sep}7d 83%`);
+		).toBe(`[us***@example.com]${sep}5h 88%${sep}7d 83%`);
 
 		expect(
 			formatPromptStatusText({
@@ -130,7 +130,7 @@ describe("TUI prompt status helpers", () => {
 				width: 120,
 				maskEmail: true,
 			}),
-		).toBe(`[*****]${sep}5h 88%${sep}7d 83%`);
+		).toBe(`[us***@example.com]${sep}5h 88%${sep}7d 83%`);
 	});
 
 	it("preserves account email in prompt status when masking is disabled", () => {
@@ -228,6 +228,47 @@ describe("TUI prompt status helpers", () => {
 		expect(details).toContain("Updated: just now");
 	});
 
+	it("partial mask keeps accounts distinguishable in prompt status", () => {
+		const one = formatPromptStatusText({
+			quota: {
+				...quota,
+				accountIndex: 1,
+				accountCount: 3,
+				accountEmail: "javi.ortiz.1982@gmail.com",
+			},
+			width: 120,
+			maskEmail: true,
+		});
+		const two = formatPromptStatusText({
+			quota: {
+				...quota,
+				accountIndex: 2,
+				accountCount: 3,
+				accountEmail: "neil@example.com",
+			},
+			width: 120,
+			maskEmail: true,
+		});
+		expect(one).toContain("[ja***@gmail.com]");
+		expect(two).toContain("[ne***@example.com]");
+		expect(one).not.toContain("javi.ortiz.1982@gmail.com");
+	});
+
+	it("masks emails embedded in free-text account labels", () => {
+		const out = formatPromptStatusText({
+			quota: {
+				...quota,
+				accountIndex: 2,
+				accountCount: 3,
+				accountLabel: "Account 2 (user2@example.com)",
+			},
+			width: 120,
+			maskEmail: true,
+		});
+		expect(out).toContain("[us***@example.com]");
+		expect(out).not.toContain("user2@example.com");
+	});
+
 	it("masks account email in quota details when requested", () => {
 		const details = formatQuotaDetailsText(
 			{
@@ -243,7 +284,7 @@ describe("TUI prompt status helpers", () => {
 			{ maskEmail: true },
 		);
 
-		expect(details).toContain("Account: [*****] (Account 2 (*****))");
+		expect(details).toContain("Account: [ne***@example.com] (Account 2 (ne***@example.com))");
 		expect(details).not.toContain("neil@example.com");
 		expect(details).toContain("5h: 88% left");
 	});

--- a/test/tui-status.test.ts
+++ b/test/tui-status.test.ts
@@ -254,6 +254,22 @@ describe("TUI prompt status helpers", () => {
 		expect(one).not.toContain("javi.ortiz.1982@gmail.com");
 	});
 
+	it("masks each punctuation-separated email in free-text labels", () => {
+		const out = formatPromptStatusText({
+			quota: {
+				...quota,
+				accountIndex: 1,
+				accountCount: 3,
+				accountEmail: "alice@example.com;bob@corp.com",
+			},
+			width: 120,
+			maskEmail: true,
+		});
+		expect(out).toContain("[al***@example.com;bo***@corp.com]");
+		expect(out).not.toContain("alice@example.com");
+		expect(out).not.toContain("bob@corp.com");
+	});
+
 	it("masks emails embedded in free-text account labels", () => {
 		const out = formatPromptStatusText({
 			quota: {

--- a/test/tui-status.test.ts
+++ b/test/tui-status.test.ts
@@ -254,6 +254,21 @@ describe("TUI prompt status helpers", () => {
 		expect(one).not.toContain("javi.ortiz.1982@gmail.com");
 	});
 
+	it("falls back to a flat mask for account values without an email pattern", () => {
+		const out = formatPromptStatusText({
+			quota: {
+				...quota,
+				accountIndex: 1,
+				accountCount: 3,
+				accountEmail: "user-without-at-sign",
+			},
+			width: 120,
+			maskEmail: true,
+		});
+		expect(out).toContain("[*****]");
+		expect(out).not.toContain("user-without-at-sign");
+	});
+
 	it("masks each punctuation-separated email in free-text labels", () => {
 		const out = formatPromptStatusText({
 			quota: {

--- a/test/tui-status.test.ts
+++ b/test/tui-status.test.ts
@@ -275,11 +275,15 @@ describe("TUI prompt status helpers", () => {
 		// the flat form as a second try at the same rung, turning masking on
 		// removes the account from a 78-column line entirely - identifying the
 		// account less rather than more, which is the opposite of the point.
+		// The domain is long enough that the partial hint overruns the
+		// 78-column budget by a clear margin and fits the 120-column one with
+		// room to spare, so the two assertions do not sit on a boundary that a
+		// change to the budget table could tip.
 		const masked = {
 			...quota,
 			accountIndex: 2,
 			accountCount: 3,
-			accountEmail: "user2@example.com",
+			accountEmail: "someone@eng.university.edu",
 		};
 
 		expect(
@@ -287,7 +291,7 @@ describe("TUI prompt status helpers", () => {
 		).toBe(`[*****]${sep}5h 88%${sep}7d 83%`);
 		expect(
 			formatPromptStatusText({ quota: masked, width: 120, maskEmail: true }),
-		).toBe(`[us***@example.com]${sep}5h 88%${sep}7d 83%`);
+		).toBe(`[so***@eng.university.edu]${sep}5h 88%${sep}7d 83%`);
 	});
 
 	it("reduces a multi-address account value to one masked address", () => {

--- a/test/tui-status.test.ts
+++ b/test/tui-status.test.ts
@@ -269,7 +269,32 @@ describe("TUI prompt status helpers", () => {
 		expect(out).not.toContain("user-without-at-sign");
 	});
 
-	it("masks each punctuation-separated email in free-text labels", () => {
+	it("falls back to the flat mask rather than dropping the account", () => {
+		// The partial hint is twelve characters longer than the flat one, and
+		// the ladder drops the account hint when a rung does not fit. Without
+		// the flat form as a second try at the same rung, turning masking on
+		// removes the account from a 78-column line entirely - identifying the
+		// account less rather than more, which is the opposite of the point.
+		const masked = {
+			...quota,
+			accountIndex: 2,
+			accountCount: 3,
+			accountEmail: "user2@example.com",
+		};
+
+		expect(
+			formatPromptStatusText({ quota: masked, width: 78, maskEmail: true }),
+		).toBe(`[*****]${sep}5h 88%${sep}7d 83%`);
+		expect(
+			formatPromptStatusText({ quota: masked, width: 120, maskEmail: true }),
+		).toBe(`[us***@example.com]${sep}5h 88%${sep}7d 83%`);
+	});
+
+	it("reduces a multi-address account value to one masked address", () => {
+		// The hint is an identity for one account, so it takes the address and
+		// discards the rest rather than masking in place. Substituting in
+		// place is what would keep the second address, or a real name, beside
+		// the mask.
 		const out = formatPromptStatusText({
 			quota: {
 				...quota,
@@ -280,9 +305,86 @@ describe("TUI prompt status helpers", () => {
 			width: 120,
 			maskEmail: true,
 		});
-		expect(out).toContain("[al***@example.com;bo***@corp.com]");
+		expect(out).toContain("[al***@example.com]");
 		expect(out).not.toContain("alice@example.com");
 		expect(out).not.toContain("bob@corp.com");
+	});
+
+	it("keeps no identifying text around the address it masks", () => {
+		const out = formatPromptStatusText({
+			quota: {
+				...quota,
+				accountIndex: 1,
+				accountCount: 3,
+				accountEmail: "Neil Smith neil@example.com",
+			},
+			width: 120,
+			maskEmail: true,
+		});
+		expect(out).toContain("[ne***@example.com]");
+		expect(out).not.toContain("Neil Smith");
+	});
+
+	it("flattens an account value whose separator is not an address boundary", () => {
+		// `/` is not a separator the token scan splits on, so both addresses
+		// land in one match. A partial mask keeps everything after the first
+		// `@`, which here is the whole of the second address.
+		const out = formatPromptStatusText({
+			quota: {
+				...quota,
+				accountIndex: 1,
+				accountCount: 3,
+				accountEmail: "alice@example.com/bob@corp.com",
+			},
+			width: 120,
+			maskEmail: true,
+		});
+		expect(out).toContain("[*****]");
+		expect(out).not.toContain("bob");
+		expect(out).not.toContain("corp.com");
+	});
+
+	it("flattens an account value that has an @ but is not an address", () => {
+		// `maskEmailForDisplay` keeps everything from the first `@` onward,
+		// which for free text is the free text.
+		const out = formatPromptStatusText({
+			quota: {
+				...quota,
+				accountIndex: 1,
+				accountCount: 3,
+				accountEmail: "Team @ Acme Corp",
+			},
+			width: 120,
+			maskEmail: true,
+		});
+		expect(out).toContain("[*****]");
+		expect(out).not.toContain("Acme");
+	});
+
+	it("masks every address in a label, whatever punctuation joins them", () => {
+		// The details dialog keeps the label's structure, so masking there is
+		// in place. Each token carrying an `@` is masked on its own, and a
+		// token carrying two is flattened rather than half-masked.
+		const details = formatQuotaDetailsText(
+			{
+				...quota,
+				accountIndex: 2,
+				accountCount: 3,
+				accountEmail: "alice@example.com",
+				accountLabel: "Shared: alice@example.com;bob@corp.com and carol@x.io/dave@y.io",
+				source: "headers",
+				fetchedAt: 1_000,
+			},
+			31_000,
+			{ maskEmail: true },
+		);
+
+		expect(details).toContain("al***@example.com;bo***@corp.com");
+		expect(details).toContain("*****");
+		expect(details).not.toContain("bob@corp.com");
+		expect(details).not.toContain("carol");
+		expect(details).not.toContain("dave");
+		expect(details).not.toContain("y.io");
 	});
 
 	it("masks emails embedded in free-text account labels", () => {


### PR DESCRIPTION
## Summary

- With `maskEmail` enabled, the prompt status line and the quota details rendered the account as a flat `[*****]`. In a multi-account pool every account looked the same, so the hint could not tell which account the quota belongs to.
- Every other human-facing surface (auth menu, CLI output, remove prompts) already centralizes on `maskEmailForDisplay` from `account-display.ts`, which keeps the first two characters and the domain: `us***@example.com`. That helper exists so all surfaces mask consistently; the status line was the only path still using its own flat mask.
- `formatAccountEmail` and `maskEmailsInText` in `tui-status.ts` now call the shared helper. The status line shows `[ja***@gmail.com]` instead of `[*****]`, accounts on the same provider stay distinguishable by prefix and domain, and the masked hint (18 chars for typical addresses) still fits the status width budgets.

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`

`test/tui-status.test.ts`: the two existing masking tests now assert the partial format (`[us***@example.com]`, `[ne***@example.com]`). Two new tests check that two masked accounts stay distinguishable, and that emails inside free-text account labels get masked. 16/16 pass in the file. Full suite: the 13 failures in `test/standalone-cli.test.ts` are pre-existing on `main` without this change; this PR does not touch that file.

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue: none.
- Follow-up work: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Email addresses in status displays are now partially masked while retaining useful identifying details.
  * Multiple account addresses remain distinguishable when displayed together.
  * Email addresses embedded in account labels and quota details are masked consistently.
  * Punctuation-separated email addresses are handled correctly during masking.
  * Values without a recognizable email pattern use a fully masked display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr aligns tui account masking with the shared partial-email display policy.
- prompt and quota-detail account hints now use `maskEmailForDisplay`.
- ambiguous multi-address tokens fall back to the flat mask.
- narrow status lines retain a flat masked account hint when the partial form does not fit.
- vitest coverage includes punctuation-separated addresses, embedded labels, ambiguous tokens, and width fallback behavior.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge with no outstanding correctness, privacy-contract, token-safety, windows-filesystem, or concurrency issue.

the previous punctuation-separation finding was manually resolved, and the current implementation masks each separated address while flattening ambiguous multi-address tokens. the newly visible prefix and domain match the repository’s documented shared masking contract.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/tui-status.ts | centralizes partial email masking, safely handles ambiguous tokens, and preserves account hints across width fallbacks. |
| test/tui-status.test.ts | adds focused masking and width-fallback coverage for the revised tui behavior. |

</details>

<sub>Reviews (4): Last reviewed commit: ["test(tui): pin the mask-fallback widths ..."](https://github.com/ndycode/oc-codex-multi-auth/commit/e682da55ddc098ea30089512b7837e4cab038f94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60786723)</sub>

**Context used:**

- Knowledge Base — [Terminal UI and status reporting](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/terminal-ui-and-status.md)

<!-- /greptile_comment -->