### PR TITLE
fix(accounts): clear the stale org-derived label, and name accounts without it

### DIFF
--- a/lib/auth/token-utils.ts
+++ b/lib/auth/token-utils.ts
@@ -82,6 +82,38 @@ export function isGeneratedAccountLabel(label: string | undefined): boolean {
 }
 
 /**
+ * Whether a stored label is one this plugin generated for *this* account.
+ *
+ * {@link isGeneratedAccountLabel} answers a softer question - may a login
+ * replace this label - and deliberately treats any trailing `[id:…]` as
+ * generated, because the worst case there is that a login overwrites a name
+ * with a fresh one. Deleting a label outright is not reversible, and
+ * `codex-label` accepts any string, so `Work [id:mine]` is a name someone is
+ * allowed to have typed.
+ *
+ * Every generator here emits the account's own id suffix in that marker, so
+ * the stricter test compares it against what this account's id would produce.
+ * A label carrying an arbitrary word, someone else's suffix, or belonging to
+ * an account with no stored id to compare against, is left alone.
+ *
+ * A user who types a label ending in their own real id suffix is
+ * indistinguishable from the generator and loses it. Nothing in the stored
+ * data separates those two cases; the alternative is deleting every
+ * `[id:…]` label, which is the strictly worse trade.
+ */
+export function isStaleGeneratedAccountLabel(
+	label: string | undefined,
+	accountId: string | undefined,
+): boolean {
+	const normalizedLabel = toStringValue(label);
+	const normalizedId = toStringValue(accountId);
+	if (!normalizedLabel || !normalizedId) return false;
+	const marker = normalizedLabel.match(GENERATED_LABEL_PATTERN)?.[0];
+	if (!marker) return false;
+	return marker === ` [id:${formatAccountIdSuffix(normalizedId)}]`;
+}
+
+/**
  * Extracts account ID from a JWT payload.
  */
 function extractAccountIdFromPayload(payload: JWTPayload | Record<string, unknown> | null): string | undefined {

--- a/lib/storage/normalize.ts
+++ b/lib/storage/normalize.ts
@@ -8,7 +8,7 @@
  */
 
 import { createLogger } from "../logger.js";
-import { extractAccountUserId } from "../auth/token-utils.js";
+import { extractAccountUserId, isGeneratedAccountLabel } from "../auth/token-utils.js";
 import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
 import { AccountStorageV2DetectionSchema } from "../schemas.js";
 import { StorageError } from "./errors.js";
@@ -32,6 +32,35 @@ import {
 const log = createLogger("storage");
 
 type AnyAccountStorage = AccountStorageV1 | AccountStorageV3;
+
+/**
+ * Drops a label an earlier build generated from an API-platform organization.
+ *
+ * Builds up to 6.17 named a ChatGPT account after an organization read from
+ * the `id_token_add_organizations` claims, storing a personal subscription as
+ * "<api org> (role:owner) [id:c487c4]". 6.18 stopped generating that label and
+ * clears it on login, since every surface prints `accountLabel` verbatim while
+ * the email and account id already render from their own fields.
+ *
+ * Login is the only thing that clears it, and a refresh token rotates for
+ * months without one, so a pool written by an older build shows the wrong
+ * organization indefinitely. Doing it here instead means the first read or
+ * write by a build that no longer generates the label drops it, with no
+ * re-authentication.
+ *
+ * Only the generated shape goes: a name set with `codex-label` carries no
+ * `[id:...]` marker, so `isGeneratedAccountLabel` reports it as the user's.
+ * That predicate also calls a blank label generated, which is why an absent
+ * or empty one returns early rather than being deleted.
+ */
+function dropStaleGeneratedLabel(account: AccountMetadataV3): AccountMetadataV3 {
+  const label = account.accountLabel;
+  if (typeof label !== "string" || !label.trim()) return account;
+  if (!isGeneratedAccountLabel(label)) return account;
+  const next = { ...account };
+  delete next.accountLabel;
+  return next;
+}
 
 /**
  * Normalizes and validates account storage data, migrating from v1 to v3 if needed.
@@ -123,9 +152,10 @@ export function normalizeAccountStorage(
   );
 
   const accountsWithMemberIdentity = validAccounts.map((account) => {
-    if (account.accountUserId?.trim()) return account;
-    const accountUserId = extractAccountUserId(account.accessToken);
-    return accountUserId ? { ...account, accountUserId } : account;
+    const named = dropStaleGeneratedLabel(account);
+    if (named.accountUserId?.trim()) return named;
+    const accountUserId = extractAccountUserId(named.accessToken);
+    return accountUserId ? { ...named, accountUserId } : named;
   });
   const deduplicatedAccounts = deduplicateAccountsForStorage(accountsWithMemberIdentity);
 

--- a/lib/storage/normalize.ts
+++ b/lib/storage/normalize.ts
@@ -8,7 +8,7 @@
  */
 
 import { createLogger } from "../logger.js";
-import { extractAccountUserId, isGeneratedAccountLabel } from "../auth/token-utils.js";
+import { extractAccountUserId, isStaleGeneratedAccountLabel } from "../auth/token-utils.js";
 import { MODEL_FAMILIES, type ModelFamily } from "../prompts/codex.js";
 import { AccountStorageV2DetectionSchema } from "../schemas.js";
 import { StorageError } from "./errors.js";
@@ -48,17 +48,31 @@ type AnyAccountStorage = AccountStorageV1 | AccountStorageV3;
  * write by a build that no longer generates the label drops it, with no
  * re-authentication.
  *
- * Only the generated shape goes: a name set with `codex-label` carries no
- * `[id:...]` marker, so `isGeneratedAccountLabel` reports it as the user's.
- * That predicate also calls a blank label generated, which is why an absent
- * or empty one returns early rather than being deleted.
+ * Only the generated shape goes. `isStaleGeneratedAccountLabel` requires the
+ * trailing `[id:…]` marker to hold this account's own id suffix, which is what
+ * every generator here emits, so a name someone typed with `codex-label` is
+ * left alone even when it happens to end in `[id:mine]`. Deleting a label has
+ * no undo, so the looser `isGeneratedAccountLabel` - which governs whether a
+ * login may *replace* a label - is deliberately not the predicate used here.
+ *
+ * This runs on every read and write rather than once behind a storage-version
+ * bump: v3 carries no marker to gate on, and adding one would mean a v4
+ * migration for a check that is a single regex per account and idempotent
+ * once the label is gone. The cost of retiring it later is a code deletion,
+ * not a data migration.
  */
 function dropStaleGeneratedLabel(account: AccountMetadataV3): AccountMetadataV3 {
   const label = account.accountLabel;
   if (typeof label !== "string" || !label.trim()) return account;
-  if (!isGeneratedAccountLabel(label)) return account;
+  if (!isStaleGeneratedAccountLabel(label, account.accountId)) return account;
   const next = { ...account };
   delete next.accountLabel;
+  // A user-visible field is disappearing, so say so: without this an account
+  // renaming itself from "DreamHost API (role:owner) [id:c487c4]" to
+  // "Account 1" leaves nothing behind to diagnose.
+  log.info("dropping stale generated account label", {
+    accountIdSuffix: account.accountId?.slice(-6),
+  });
   return next;
 }
 

--- a/scripts/install-oc-codex-multi-auth-core.js
+++ b/scripts/install-oc-codex-multi-auth-core.js
@@ -307,6 +307,29 @@ function mergeStandaloneAccounts(target, source) {
 	return mergeStandaloneAccounts(source, target);
 }
 
+// Mirror of `isStaleGeneratedAccountLabel` / `dropStaleGeneratedLabel` in
+// lib/auth/token-utils.ts and lib/storage/normalize.ts. The standalone CLI
+// reads the pool through this normalizer and never through the compiled
+// `normalizeAccountStorage`, so without the mirror `status`, `list`, `health`,
+// `doctor` and `dashboard` keep printing the org-derived label the plugin
+// itself now drops - next to the account id, which is the identity the label
+// was misnaming. The marker must hold this account's own id suffix so a name
+// set with `codex-label` survives.
+const GENERATED_LABEL_PATTERN = /\s\[id:[^\]]*\]$/;
+
+function dropStaleStandaloneLabel(account) {
+	const label = typeof account?.accountLabel === "string" ? account.accountLabel.trim() : "";
+	const accountId = typeof account?.accountId === "string" ? account.accountId.trim() : "";
+	if (!label || !accountId) return account;
+	const marker = label.match(GENERATED_LABEL_PATTERN)?.[0];
+	if (!marker) return account;
+	const suffix = accountId.length > 6 ? accountId.slice(-6) : accountId;
+	if (marker !== ` [id:${suffix}]`) return account;
+	const next = { ...account };
+	delete next.accountLabel;
+	return next;
+}
+
 function normalizeStandaloneStorage(storage) {
 	if (!Array.isArray(storage.accounts)) return storage;
 	const accounts = [...storage.accounts];
@@ -324,7 +347,9 @@ function normalizeStandaloneStorage(storage) {
 			if (sourceIndex === i) break;
 		}
 	}
-	const normalizedAccounts = accounts.filter((_, index) => !removed.has(index));
+	const normalizedAccounts = accounts
+		.filter((_, index) => !removed.has(index))
+		.map(dropStaleStandaloneLabel);
 	return {
 		...storage,
 		accounts: normalizedAccounts,
@@ -332,8 +357,13 @@ function normalizeStandaloneStorage(storage) {
 	};
 }
 
+// A short value has no room for a head/tail mask, and `doctor` output is the
+// thing users paste into issues, so it is replaced outright rather than
+// returned verbatim: an email such as `me@x.io` is eight characters and would
+// otherwise print in full wherever masking is supposed to be on.
 function maskValue(value, includeSensitive) {
-	if (includeSensitive || typeof value !== "string" || value.length <= 8) return value;
+	if (includeSensitive || typeof value !== "string" || !value) return value;
+	if (value.length <= 8) return "*****";
 	return `${value.slice(0, 4)}...${value.slice(-4)}`;
 }
 
@@ -341,11 +371,12 @@ function maskValue(value, includeSensitive) {
 // in-conversation surfaces print as `id:`. Four when it is masked, which is
 // the tail `maskValue` discloses as `accountId` in the same payload, so the
 // printed identity never reveals more of an id than the field beside it.
+// Both read the same normalized id, or a trailing space would shift
+// `maskValue`'s window and disclose one character more than this suffix.
 function accountIdSuffix(accountId, includeSensitive) {
-	const trimmed = typeof accountId === "string" ? accountId.trim() : "";
-	if (!trimmed) return undefined;
+	if (!accountId) return undefined;
 	const width = includeSensitive ? 6 : 4;
-	return trimmed.length > width ? trimmed.slice(-width) : trimmed;
+	return accountId.length > width ? accountId.slice(-width) : accountId;
 }
 
 function summarizeStandaloneAccounts(storage, includeSensitive, tag) {
@@ -356,22 +387,27 @@ function summarizeStandaloneAccounts(storage, includeSensitive, tag) {
 		.filter(({ account }) => !normalizedTag ||
 			(Array.isArray(account?.accountTags) &&
 				account.accountTags.some((entry) => String(entry).toLowerCase() === normalizedTag)))
-		.map(({ account, index }) => ({
-			index,
-			label: account?.accountLabel ?? `Account ${index + 1}`,
-			email: maskValue(account?.email, includeSensitive),
-			accountId: maskValue(account?.accountId, includeSensitive),
-			idSuffix: accountIdSuffix(account?.accountId, includeSensitive),
-			accountIdSource: account?.accountIdSource,
-			enabled: account?.enabled !== false,
-			hasRefreshToken: typeof account?.refreshToken === "string" && account.refreshToken.length > 0,
-			hasAccessToken: typeof account?.accessToken === "string" && account.accessToken.length > 0,
-			expiresAt: account?.expiresAt,
-			expired: typeof account?.expiresAt === "number" ? account.expiresAt <= Date.now() : undefined,
-			tags: Array.isArray(account?.accountTags) ? account.accountTags : [],
-			note: account?.accountNote,
-			rateLimitResetTimes: account?.rateLimitResetTimes ?? {},
-		}));
+		.map(({ account, index }) => {
+			const trimmedId =
+				typeof account?.accountId === "string" ? account.accountId.trim() : "";
+			const accountId = trimmedId || undefined;
+			return {
+				index,
+				label: account?.accountLabel ?? `Account ${index + 1}`,
+				email: maskValue(account?.email, includeSensitive),
+				accountId: maskValue(accountId, includeSensitive),
+				idSuffix: accountIdSuffix(accountId, includeSensitive),
+				accountIdSource: account?.accountIdSource,
+				enabled: account?.enabled !== false,
+				hasRefreshToken: typeof account?.refreshToken === "string" && account.refreshToken.length > 0,
+				hasAccessToken: typeof account?.accessToken === "string" && account.accessToken.length > 0,
+				expiresAt: account?.expiresAt,
+				expired: typeof account?.expiresAt === "number" ? account.expiresAt <= Date.now() : undefined,
+				tags: Array.isArray(account?.accountTags) ? account.accountTags : [],
+				note: account?.accountNote,
+				rateLimitResetTimes: account?.rateLimitResetTimes ?? {},
+			};
+		});
 }
 
 function printStandaloneResult(command, payload, json) {

--- a/scripts/install-oc-codex-multi-auth-core.js
+++ b/scripts/install-oc-codex-multi-auth-core.js
@@ -357,26 +357,37 @@ function normalizeStandaloneStorage(storage) {
 	};
 }
 
-// A short value has no room for a head/tail mask, and `doctor` output is the
-// thing users paste into issues, so it is replaced outright rather than
-// returned verbatim: an email such as `me@x.io` is eight characters and would
-// otherwise print in full wherever masking is supposed to be on.
+const MASKED_VALUE = "*****";
+// The head/tail mask keeps eight characters, so it conceals nothing worth
+// concealing below thirteen: `me@x.io` would print in full and `me@x.io12`
+// all but its middle character. `doctor` output is what users paste into
+// issues, so anything shorter is replaced outright instead. Input is trimmed
+// first, or `" me@x.io "` clears the cutoff on padding alone and drops back
+// into the partial mask.
+const MASK_MIN_LENGTH = 13;
+
 function maskValue(value, includeSensitive) {
-	if (includeSensitive || typeof value !== "string" || !value) return value;
-	if (value.length <= 8) return "*****";
-	return `${value.slice(0, 4)}...${value.slice(-4)}`;
+	if (includeSensitive || typeof value !== "string") return value;
+	const trimmed = value.trim();
+	if (!trimmed) return trimmed;
+	if (trimmed.length < MASK_MIN_LENGTH) return MASKED_VALUE;
+	return `${trimmed.slice(0, 4)}...${trimmed.slice(-4)}`;
 }
 
 // Six characters when the id is shown in full, matching what the
-// in-conversation surfaces print as `id:`. Four when it is masked, which is
-// the tail `maskValue` discloses as `accountId` in the same payload, so the
-// printed identity never reveals more of an id than the field beside it.
-// Both read the same normalized id, or a trailing space would shift
-// `maskValue`'s window and disclose one character more than this suffix.
+// in-conversation surfaces print as `id:`. Four when it is head/tail masked,
+// which is the tail `maskValue` already discloses as `accountId` in the same
+// payload, so the printed identity never reveals more of an id than the field
+// beside it. Nothing at all when the id was too short for that mask: the
+// `accountId` next to it is then `*****`, and four raw characters of a short
+// id can be the whole id.
 function accountIdSuffix(accountId, includeSensitive) {
 	if (!accountId) return undefined;
-	const width = includeSensitive ? 6 : 4;
-	return accountId.length > width ? accountId.slice(-width) : accountId;
+	if (includeSensitive) {
+		return accountId.length > 6 ? accountId.slice(-6) : accountId;
+	}
+	if (accountId.length < MASK_MIN_LENGTH) return undefined;
+	return accountId.slice(-4);
 }
 
 function summarizeStandaloneAccounts(storage, includeSensitive, tag) {

--- a/scripts/install-oc-codex-multi-auth-core.js
+++ b/scripts/install-oc-codex-multi-auth-core.js
@@ -337,6 +337,17 @@ function maskValue(value, includeSensitive) {
 	return `${value.slice(0, 4)}...${value.slice(-4)}`;
 }
 
+// Six characters when the id is shown in full, matching what the
+// in-conversation surfaces print as `id:`. Four when it is masked, which is
+// the tail `maskValue` discloses as `accountId` in the same payload, so the
+// printed identity never reveals more of an id than the field beside it.
+function accountIdSuffix(accountId, includeSensitive) {
+	const trimmed = typeof accountId === "string" ? accountId.trim() : "";
+	if (!trimmed) return undefined;
+	const width = includeSensitive ? 6 : 4;
+	return trimmed.length > width ? trimmed.slice(-width) : trimmed;
+}
+
 function summarizeStandaloneAccounts(storage, includeSensitive, tag) {
 	const accounts = Array.isArray(storage?.accounts) ? storage.accounts : [];
 	const normalizedTag = typeof tag === "string" ? tag.trim().toLowerCase() : "";
@@ -350,6 +361,7 @@ function summarizeStandaloneAccounts(storage, includeSensitive, tag) {
 			label: account?.accountLabel ?? `Account ${index + 1}`,
 			email: maskValue(account?.email, includeSensitive),
 			accountId: maskValue(account?.accountId, includeSensitive),
+			idSuffix: accountIdSuffix(account?.accountId, includeSensitive),
 			accountIdSource: account?.accountIdSource,
 			enabled: account?.enabled !== false,
 			hasRefreshToken: typeof account?.refreshToken === "string" && account.refreshToken.length > 0,
@@ -373,7 +385,11 @@ function printStandaloneResult(command, payload, json) {
 	console.log(`Accounts: ${payload.totalAccounts}`);
 	if (Array.isArray(payload.accounts)) {
 		for (const account of payload.accounts) {
-			console.log(`- [${account.index}] ${account.label} enabled=${account.enabled} refresh=${account.hasRefreshToken} access=${account.hasAccessToken}`);
+			const identity = [account.email, account.idSuffix ? `id:${account.idSuffix}` : undefined]
+				.filter(Boolean)
+				.join(", ");
+			const name = identity ? `${account.label} (${identity})` : account.label;
+			console.log(`- [${account.index}] ${name} enabled=${account.enabled} refresh=${account.hasRefreshToken} access=${account.hasAccessToken}`);
 		}
 	}
 	if (payload.error) console.log(`Error: ${payload.error}`);

--- a/test/standalone-cli.test.ts
+++ b/test/standalone-cli.test.ts
@@ -7,6 +7,16 @@ async function createTempHome() {
 	return mkdtemp(join(tmpdir(), "oc-codex-standalone-"));
 }
 
+async function seedPool(home: string, accounts: unknown[]) {
+	const opencodeDir = join(home, ".opencode");
+	await mkdir(opencodeDir, { recursive: true });
+	await writeFile(
+		join(opencodeDir, "oc-codex-multi-auth-accounts.json"),
+		JSON.stringify({ version: 3, activeIndex: 0, accounts }, null, 2),
+		"utf-8",
+	);
+}
+
 describe("standalone oc-codex-multi-auth CLI commands", () => {
 	let tempHome: string | null = null;
 
@@ -53,6 +63,97 @@ describe("standalone oc-codex-multi-auth CLI commands", () => {
 		const output = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0]));
 		expect(output.totalAccounts).toBe(1);
 		expect(output.accounts[0].email).toBe("user....com");
+	});
+
+	it("status: the masked id suffix reveals no more than the masked accountId beside it", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		await seedPool(tempHome, [
+			{
+				email: "user@example.com",
+				accountId: "acct_123456789",
+				accountIdSource: "token",
+				refreshToken: "refresh-token",
+				addedAt: 1000,
+				lastUsed: 2000,
+			},
+		]);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await expect(runInstaller(["status", "--json"], {
+			env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+		})).resolves.toMatchObject({ exitCode: 0 });
+
+		const account = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0])).accounts[0];
+		expect(account.accountId).toBe("acct...6789");
+		expect(account.idSuffix).toBe("6789");
+	});
+
+	it("status: --include-sensitive keeps the six-character id suffix the other surfaces print", async () => {
+		vi.resetModules();
+		tempHome = await createTempHome();
+		await seedPool(tempHome, [
+			{
+				email: "user@example.com",
+				accountId: "acct_123456789",
+				accountIdSource: "token",
+				refreshToken: "refresh-token",
+				addedAt: 1000,
+				lastUsed: 2000,
+			},
+		]);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await expect(runInstaller(["status", "--json", "--include-sensitive"], {
+			env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+		})).resolves.toMatchObject({ exitCode: 0 });
+
+		const account = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0])).accounts[0];
+		expect(account.accountId).toBe("acct_123456789");
+		expect(account.idSuffix).toBe("456789");
+	});
+
+	it("list: the masked id suffix still separates two accounts that share an email", async () => {
+		// A masked row must still say which account it is. One subscription can
+		// hold several workspaces under a single email, so with no suffix at
+		// all these two rows read identically.
+		vi.resetModules();
+		tempHome = await createTempHome();
+		await seedPool(tempHome, [
+			{
+				email: "dup@example.com",
+				accountId: "acct_0000000000aaaa",
+				accountIdSource: "token",
+				refreshToken: "refresh-a",
+				addedAt: 1000,
+				lastUsed: 2000,
+			},
+			{
+				email: "dup@example.com",
+				accountId: "acct_0000000000bbbb",
+				accountIdSource: "token",
+				refreshToken: "refresh-b",
+				addedAt: 1000,
+				lastUsed: 2000,
+			},
+		]);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await expect(runInstaller(["list"], {
+			env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+		})).resolves.toMatchObject({ exitCode: 0 });
+
+		const identities = logSpy.mock.calls
+			.map((call) => String(call[0]))
+			.filter((line) => line.startsWith("- ["))
+			.map((line) => line.slice(line.indexOf("("), line.indexOf(")") + 1));
+
+		expect(identities).toHaveLength(2);
+		expect(identities[0]).toBe("(dup@....com, id:aaaa)");
+		expect(identities[1]).toBe("(dup@....com, id:bbbb)");
 	});
 
 	it("rejects unknown positional commands instead of installing", async () => {

--- a/test/standalone-cli.test.ts
+++ b/test/standalone-cli.test.ts
@@ -7,6 +7,15 @@ async function createTempHome() {
 	return mkdtemp(join(tmpdir(), "oc-codex-standalone-"));
 }
 
+// The identity group is the last `(…)` before the trailing `enabled=` flags.
+// Slicing between the first `(` and the first `)` instead would grab
+// `(role:owner)` out of any label that carries parentheses of its own.
+function extractIdentity(line: string) {
+	const head = line.slice(0, line.indexOf(" enabled="));
+	const open = head.lastIndexOf("(");
+	return open === -1 ? "" : head.slice(open);
+}
+
 async function seedPool(home: string, accounts: unknown[]) {
 	const opencodeDir = join(home, ".opencode");
 	await mkdir(opencodeDir, { recursive: true });
@@ -149,11 +158,86 @@ describe("standalone oc-codex-multi-auth CLI commands", () => {
 		const identities = logSpy.mock.calls
 			.map((call) => String(call[0]))
 			.filter((line) => line.startsWith("- ["))
-			.map((line) => line.slice(line.indexOf("("), line.indexOf(")") + 1));
+			.map(extractIdentity);
 
 		expect(identities).toHaveLength(2);
 		expect(identities[0]).toBe("(dup@....com, id:aaaa)");
 		expect(identities[1]).toBe("(dup@....com, id:bbbb)");
+	});
+
+	it("list: drops the org-derived label the plugin no longer generates", async () => {
+		// The standalone CLI reads the pool through its own normalizer, so
+		// without a mirror of the drop it keeps printing the wrong
+		// organization beside the very account id that label was misnaming.
+		vi.resetModules();
+		tempHome = await createTempHome();
+		await seedPool(tempHome, [
+			{
+				email: "personal@example.com",
+				accountId: "acct_9f21c487c4",
+				accountLabel: "DreamHost API (role:owner) [id:c487c4]",
+				accountIdSource: "token",
+				refreshToken: "refresh-a",
+				addedAt: 1000,
+				lastUsed: 2000,
+			},
+			{
+				// A name someone typed. The marker does not hold this
+				// account's id suffix, so it is not the plugin's to delete.
+				email: "work@example.com",
+				accountId: "acct_0000abcdef",
+				accountLabel: "Work [id:mine]",
+				accountIdSource: "token",
+				refreshToken: "refresh-b",
+				addedAt: 1000,
+				lastUsed: 2000,
+			},
+		]);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await expect(runInstaller(["list"], {
+			env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+		})).resolves.toMatchObject({ exitCode: 0 });
+
+		const rows = logSpy.mock.calls
+			.map((call) => String(call[0]))
+			.filter((line) => line.startsWith("- ["));
+
+		expect(rows[0]).toContain("Account 1 (pers....com, id:87c4)");
+		expect(rows[0]).not.toContain("DreamHost");
+		expect(rows[1]).toContain("Work [id:mine] (work....com, id:cdef)");
+	});
+
+	it("list: replaces an email too short to mask instead of printing it", async () => {
+		// `doctor` and friends share this printer and are what users paste
+		// into issues. A head/tail mask has no room in eight characters, so
+		// the value is replaced outright rather than returned verbatim.
+		vi.resetModules();
+		tempHome = await createTempHome();
+		await seedPool(tempHome, [
+			{
+				email: "me@x.io",
+				accountId: "acct_0000abcdef",
+				accountIdSource: "token",
+				refreshToken: "refresh-a",
+				addedAt: 1000,
+				lastUsed: 2000,
+			},
+		]);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await expect(runInstaller(["list"], {
+			env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+		})).resolves.toMatchObject({ exitCode: 0 });
+
+		const rows = logSpy.mock.calls
+			.map((call) => String(call[0]))
+			.filter((line) => line.startsWith("- ["));
+
+		expect(rows[0]).toContain("(*****, id:cdef)");
+		expect(rows[0]).not.toContain("me@x.io");
 	});
 
 	it("rejects unknown positional commands instead of installing", async () => {

--- a/test/standalone-cli.test.ts
+++ b/test/standalone-cli.test.ts
@@ -209,10 +209,10 @@ describe("standalone oc-codex-multi-auth CLI commands", () => {
 		expect(rows[1]).toContain("Work [id:mine] (work....com, id:cdef)");
 	});
 
-	it("list: replaces an email too short to mask instead of printing it", async () => {
+	it("list: replaces a value the head/tail mask cannot conceal", async () => {
 		// `doctor` and friends share this printer and are what users paste
-		// into issues. A head/tail mask has no room in eight characters, so
-		// the value is replaced outright rather than returned verbatim.
+		// into issues. `first4...last4` conceals nothing below thirteen
+		// characters, and padding must not clear the cutoff on its own.
 		vi.resetModules();
 		tempHome = await createTempHome();
 		await seedPool(tempHome, [
@@ -221,6 +221,14 @@ describe("standalone oc-codex-multi-auth CLI commands", () => {
 				accountId: "acct_0000abcdef",
 				accountIdSource: "token",
 				refreshToken: "refresh-a",
+				addedAt: 1000,
+				lastUsed: 2000,
+			},
+			{
+				email: "  me@x.io12  ",
+				accountId: "acct_0000abcdef",
+				accountIdSource: "token",
+				refreshToken: "refresh-b",
 				addedAt: 1000,
 				lastUsed: 2000,
 			},
@@ -238,6 +246,37 @@ describe("standalone oc-codex-multi-auth CLI commands", () => {
 
 		expect(rows[0]).toContain("(*****, id:cdef)");
 		expect(rows[0]).not.toContain("me@x.io");
+		expect(rows[1]).toContain("(*****, id:cdef)");
+		expect(rows[1]).not.toContain("me@x");
+	});
+
+	it("status: omits the id suffix when the account id was masked outright", async () => {
+		// The suffix is only safe because it reveals no more than the masked
+		// `accountId` printed beside it. When that field is `*****`, four raw
+		// characters of a short id can be the entire id.
+		vi.resetModules();
+		tempHome = await createTempHome();
+		await seedPool(tempHome, [
+			{
+				email: "user@example.com",
+				accountId: "ab12cd",
+				accountIdSource: "token",
+				refreshToken: "refresh-token",
+				addedAt: 1000,
+				lastUsed: 2000,
+			},
+		]);
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const { runInstaller } = await import("../scripts/install-oc-codex-multi-auth-core.js");
+
+		await expect(runInstaller(["status", "--json"], {
+			env: { ...process.env, HOME: tempHome, USERPROFILE: tempHome },
+		})).resolves.toMatchObject({ exitCode: 0 });
+
+		const account = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0])).accounts[0];
+		expect(account.accountId).toBe("*****");
+		expect(account.idSuffix).toBeUndefined();
+		expect(JSON.stringify(account)).not.toContain("12cd");
 	});
 
 	it("rejects unknown positional commands instead of installing", async () => {

--- a/test/storage-async.test.ts
+++ b/test/storage-async.test.ts
@@ -136,6 +136,44 @@ describe("Storage Module - Async Operations", () => {
       expect(result?.activeIndex).toBe(0);
     });
 
+    it("drops an org-derived label an older build generated", () => {
+      const input = {
+        version: 3,
+        accounts: [
+          {
+            refreshToken: "token1",
+            accountLabel: "DreamHost API (role:owner) [id:c487c4]",
+            email: "personal@example.com",
+            addedAt: 1000,
+            lastUsed: 2000,
+          },
+        ],
+        activeIndex: 0,
+      };
+
+      const result = normalizeAccountStorage(input);
+      expect(result?.accounts[0]).not.toHaveProperty("accountLabel");
+      expect(result?.accounts[0]?.email).toBe("personal@example.com");
+      expect(result?.accounts[0]?.refreshToken).toBe("token1");
+    });
+
+    it("keeps a label the user set with codex-label", () => {
+      const input = {
+        version: 3,
+        accounts: [
+          { refreshToken: "token1", accountLabel: "Work", addedAt: 1000, lastUsed: 2000 },
+          { refreshToken: "token2", accountLabel: "", addedAt: 1000, lastUsed: 2000 },
+          { refreshToken: "token3", addedAt: 1000, lastUsed: 2000 },
+        ],
+        activeIndex: 0,
+      };
+
+      const result = normalizeAccountStorage(input);
+      expect(result?.accounts[0]?.accountLabel).toBe("Work");
+      expect(result?.accounts[1]?.accountLabel).toBe("");
+      expect(result?.accounts[2]).not.toHaveProperty("accountLabel");
+    });
+
     it("preserves per-family active indices", () => {
       const input: AccountStorageV3 = {
         version: 3,

--- a/test/storage-async.test.ts
+++ b/test/storage-async.test.ts
@@ -142,6 +142,7 @@ describe("Storage Module - Async Operations", () => {
         accounts: [
           {
             refreshToken: "token1",
+            accountId: "acct_9f21c487c4",
             accountLabel: "DreamHost API (role:owner) [id:c487c4]",
             email: "personal@example.com",
             addedAt: 1000,
@@ -152,9 +153,11 @@ describe("Storage Module - Async Operations", () => {
       };
 
       const result = normalizeAccountStorage(input);
-      expect(result?.accounts[0]).not.toHaveProperty("accountLabel");
-      expect(result?.accounts[0]?.email).toBe("personal@example.com");
-      expect(result?.accounts[0]?.refreshToken).toBe("token1");
+      expect(result).not.toBeNull();
+      const account = result!.accounts[0]!;
+      expect(account).not.toHaveProperty("accountLabel");
+      expect(account.email).toBe("personal@example.com");
+      expect(account.refreshToken).toBe("token1");
     });
 
     it("keeps a label the user set with codex-label", () => {
@@ -169,9 +172,51 @@ describe("Storage Module - Async Operations", () => {
       };
 
       const result = normalizeAccountStorage(input);
-      expect(result?.accounts[0]?.accountLabel).toBe("Work");
-      expect(result?.accounts[1]?.accountLabel).toBe("");
-      expect(result?.accounts[2]).not.toHaveProperty("accountLabel");
+      expect(result).not.toBeNull();
+      expect(result!.accounts[0]!.accountLabel).toBe("Work");
+      expect(result!.accounts[1]!.accountLabel).toBe("");
+      expect(result!.accounts[2]!).not.toHaveProperty("accountLabel");
+    });
+
+    it("keeps a user label that ends in a bracketed id of its own", () => {
+      // `codex-label` accepts any string, so the trailing `[id:…]` marker is
+      // not on its own proof the plugin wrote the label. Only a marker
+      // holding this account's own id suffix is, and deleting is not
+      // reversible.
+      const input = {
+        version: 3,
+        accounts: [
+          {
+            refreshToken: "token1",
+            accountId: "acct_9f21c487c4",
+            accountLabel: "Work [id:mine]",
+            addedAt: 1000,
+            lastUsed: 2000,
+          },
+          {
+            refreshToken: "token2",
+            accountId: "acct_0000abcdef",
+            accountLabel: "Personal [id:c487c4]",
+            addedAt: 1000,
+            lastUsed: 2000,
+          },
+          {
+            // No stored id to compare the marker against, so nothing is
+            // provably generated and the label stays.
+            refreshToken: "token3",
+            accountLabel: "Legacy [id:c487c4]",
+            addedAt: 1000,
+            lastUsed: 2000,
+          },
+        ],
+        activeIndex: 0,
+      };
+
+      const result = normalizeAccountStorage(input);
+      expect(result).not.toBeNull();
+      expect(result!.accounts[0]!.accountLabel).toBe("Work [id:mine]");
+      expect(result!.accounts[1]!.accountLabel).toBe("Personal [id:c487c4]");
+      expect(result!.accounts[2]!.accountLabel).toBe("Legacy [id:c487c4]");
     });
 
     it("preserves per-family active indices", () => {


### PR DESCRIPTION
## Summary

- **What changed?** Two fixes that belong together, because the first one is what makes the second one visible.

  1. `normalizeAccountStorage` now drops the generated `accountLabel` on read as well as on write, so a pool written by an older build heals itself the first time a 6.18+ build touches it.
  2. `summarizeStandaloneAccounts` / `printStandaloneResult` now print the email and account-id suffix, so the standalone CLI can still name an account once that label is gone.

- **Why is this needed?** Builds up to 6.17 named a ChatGPT account after an organization read from the `id_token_add_organizations` claims, so a personal subscription was stored as `<some api org> (role:owner) [id:c487c4]` and every surface printed that organization as the account's name.

  6.18 stopped generating the label and clears a stale one in `persistAccountPool`, but only a **login** reaches that code. A refresh token rotates for months without one, so an existing pool keeps naming the wrong organization indefinitely and the only way out is re-authenticating every account. `normalizeAccountStorage` already rebuilds each record on the way in and out, so putting the clear there makes it a migration that costs the user nothing.

  Clearing it exposed a second problem. With no `accountLabel`, `summarizeStandaloneAccounts` falls back to `Account N` and `printStandaloneResult` prints only that field, so `list` and `status` render indistinguishable rows:

  ```
  - [0] Account 1 enabled=true refresh=true access=true
  - [1] Account 2 enabled=true refresh=true access=true
  ```

  The email and account id were already in the payload and simply not printed. They are now, matching what `codex-list` and the auth menu render through `formatAccountLabel`, so the two surfaces agree on how an account identifies itself:

  ```
  - [0] Account 1 (us***@example.com, id:c487c4) enabled=true refresh=true access=true
  ```

- **Scope of the clear.** Only the generated shape is dropped, through the plugin's own `isGeneratedAccountLabel`. A name set with `codex-label` carries no `[id:...]` marker and survives. That predicate also reports a blank label as generated, so an absent or empty one returns early instead of being deleted, which keeps the record byte-identical rather than churning it.

- **Why `idSuffix` is a new field.** It is added alongside the existing masked `accountId` rather than derived from it, because masking rewrites the middle of the value and the last six characters have to survive it to stay comparable with the id the other surfaces print.

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`

Two new cases in `test/storage-async.test.ts` cover the migration: a generated label is dropped on load, and a user-set label is preserved.

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue: none. Found while operating a six-account pool where every account displayed the name of one unrelated API organization.
- Follow-up work or rollout notes: the migration is silent and needs no release note beyond the changelog entry, since the label it removes was never user-authored. Verified against a real six-account pool: all six generated labels were gone after a single load, with the stored emails untouched.
- Suite note, not a change request: on a saturated host (load average ~75) the first full run had four timeout failures in `test/index-retry.test.ts`, `test/index.test.ts` and `test/standalone-cli.test.ts`, all against the 5s default `testTimeout`. Re-running those same three files with `--no-file-parallelism` passes 279/279. Nothing here touches those paths; flagging it only in case CI ever goes red for the same reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removes outdated, system-generated account labels when they match the account’s ID, while preserving user-defined labels.
  - Preserves email addresses, refresh tokens, and unlabeled account behavior during normalization.
  - Correctly handles labels containing parentheses and removes stale labels from standalone account lists.
  - Masks short email values consistently in standalone output.

- **Improvements**
  - Standalone account status, list, and diagnostic output displays a short account ID suffix.
  - Account IDs are masked by default, with full values available when sensitive details are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr migrates stale generated account labels out of normalized storage and adds safely redacted email and account-id context to standalone account output.
- generated labels are removed only when their marker matches the stored account id.
- user-defined labels with unrelated markers remain intact.
- standalone text and json output mask short identity values and omit unsafe short-id suffixes.
- vitest covers stale-label migration, label preservation, masking boundaries, and sensitive-output behavior.
- token safety is improved by tightening identity redaction. no windows filesystem behavior or concurrency-sensitive persistence flow is changed.

<h3>Confidence Score: 5/5</h3>

the pr appears safe to merge; the follow-up changes close the identity-disclosure edge case without introducing a blocking regression.

no actionable new failure remains. all three prior threads were manually resolved without explanatory replies, so they do not remain outstanding.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/auth/token-utils.ts | adds account-specific generated-label detection to reduce irreversible deletion of user labels. |
| lib/storage/normalize.ts | removes matching stale generated labels during canonical account normalization. |
| scripts/install-oc-codex-multi-auth-core.js | mirrors label cleanup in the standalone path and tightens identity masking. |
| test/standalone-cli.test.ts | adds vitest coverage for redaction, label cleanup, identity rendering, and sensitive output. |
| test/storage-async.test.ts | adds vitest coverage for generated-label removal and user-label preservation. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[stored account] --> B[normalize account]
    B --> C{label marker matches account id}
    C -->|yes| D[drop stale generated label]
    C -->|no| E[preserve label]
    D --> F[standalone summary]
    E --> F
    F --> G{include sensitive}
    G -->|yes| H[full identity and six-character suffix]
    G -->|no| I[masked identity and safe suffix]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(cli): stop the id suffix and short v..."](https://github.com/ndycode/oc-codex-multi-auth/commit/570470d668b860c236e8b4b55fcd591deb64656b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60841240)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Account state and secure storage](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/account-state-and-storage.md)
- Knowledge Base — [Token and credential handling](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/token-and-credential-handling.md)
- Knowledge Base — [CLI command workflows](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/cli-command-workflows.md)
- Knowledge Base — [Command and terminal experience](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/command-experience.md)
</details>


<!-- /greptile_comment -->