### PR TITLE
feat(limits): show the banked resets an account can redeem

### DIFF
--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -83,7 +83,7 @@ lib/
 | Error types | `errors.ts`, `error-sentinels.ts` | StorageError and structured sentinel errors |
 | Health monitoring | `health.ts` | account health status |
 | Account display / masking | `account-display.ts` | label-preferred rendering, `maskEmail` behavior |
-| Reset credits | `codex-reset.ts` | banked rate-limit reset credit list/redeem |
+| Reset credits | `codex-reset.ts`, `codex-usage.ts` | banked rate-limit reset credit list/redeem; `codex-usage.ts` reads the same counts off the usage endpoint for `codex-limits`, sharing `normalizeResetCreditCount` so both agree |
 | Parallel probes | `parallel-probe.ts` | concurrent health checks |
 | Runtime helpers | `runtime.ts` | routing visibility, metrics, pure helper types |
 | Graceful shutdown | `shutdown.ts` | cleanup on exit |

--- a/lib/codex-reset.ts
+++ b/lib/codex-reset.ts
@@ -86,6 +86,25 @@ function toTrimmedString(value: unknown): string | null {
 }
 
 /**
+ * Read a reset-credit counter the server stated.
+ *
+ * A count is a whole number of redeemable resets, so a negative, fractional,
+ * non-finite or non-numeric value is a payload this code cannot read rather
+ * than a zero: truncating `1.9` to `1` would silently paper over a malformed
+ * response. Returning `null` leaves the fallback to each caller, which is why
+ * the two reset-credit surfaces stay consistent about what "sane" means
+ * without sharing a fallback policy they do not agree on. The list endpoint
+ * below derives the count from the credits it also sent; the usage endpoint,
+ * which sends no list, reports the count as unknown.
+ */
+export function normalizeResetCreditCount(value: unknown): number | null {
+	if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+		return null;
+	}
+	return value;
+}
+
+/**
  * Normalize the list response.
  *
  * Credits without an `id` are dropped: an id is required to redeem, so an
@@ -113,11 +132,9 @@ export function parseCodexResetCredits(
 		});
 	}
 
-	const reported = payload.available_count;
 	const availableCount =
-		typeof reported === "number" && Number.isFinite(reported) && reported >= 0
-			? Math.trunc(reported)
-			: credits.filter((credit) => credit.isAvailable).length;
+		normalizeResetCreditCount(payload.available_count) ??
+		credits.filter((credit) => credit.isAvailable).length;
 
 	return { availableCount, credits };
 }

--- a/lib/codex-usage.ts
+++ b/lib/codex-usage.ts
@@ -50,6 +50,11 @@ export type UsageCredits = {
 	balance?: string | null;
 } | null;
 
+export type UsageResetCredits = {
+	available_count?: number | null;
+	applicable_available_count?: number | null;
+} | null;
+
 export type UsagePayload = {
 	plan_type?: string;
 	rate_limit?: UsageRateLimit;
@@ -60,6 +65,7 @@ export type UsagePayload = {
 		rate_limit?: UsageRateLimit;
 	}> | null;
 	credits?: UsageCredits;
+	rate_limit_reset_credits?: UsageResetCredits;
 };
 
 export type UsageLimitPayload = {
@@ -76,9 +82,15 @@ export type AdditionalUsageLimit = {
 	window: LimitWindow;
 };
 
+export type ResetCreditCounts = {
+	available: number;
+	applicableNow: number;
+};
+
 export type CodexUsageSummary = {
 	planType: string | null;
 	credits: string | null;
+	resetCredits: ResetCreditCounts | null;
 	primary: LimitWindow;
 	secondary: LimitWindow;
 	codeReview: LimitWindow;
@@ -233,6 +245,57 @@ export function formatUsageCredits(
 	}
 	if (credits.has_credits) return "available";
 	return undefined;
+}
+
+function toResetCreditCount(value: unknown): number | null {
+	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+		return null;
+	}
+	return Math.trunc(value);
+}
+
+/**
+ * Read the redeemable rate-limit resets the usage response already carries.
+ *
+ * These are a different currency from `credits`, and an account routinely
+ * holds both readings at once: a spent purchase balance alongside banked
+ * resets. Reporting only `credits` therefore says "you have nothing" while a
+ * full reset is waiting to be redeemed.
+ *
+ * `applicable_available_count` is the subset redeemable right now, which is
+ * smaller than the banked count whenever no window is exhausted yet. A
+ * response that omits it predates the field rather than reporting zero, so it
+ * defaults to the banked count - defaulting to zero would report every banked
+ * reset as unusable. Omitted means absent OR null: this endpoint sends a
+ * literal JSON null for a field it has no value for, which is how
+ * `secondary_window` arrives on every single-window plan.
+ *
+ * A count the server did state and this code cannot read is a different thing,
+ * and defaulting it would invent an answer. A negative, non-numeric or
+ * larger-than-banked applicable count makes the whole reading unknown rather
+ * than fully applicable, because over-reporting sends someone to redeem a
+ * credit that is not there.
+ */
+export function parseUsageResetCredits(
+	source: UsageResetCredits | undefined,
+): ResetCreditCounts | null {
+	if (typeof source !== "object" || source === null) return null;
+	const available = toResetCreditCount(source.available_count);
+	if (available === null) return null;
+
+	const stated = source.applicable_available_count;
+	if (stated === undefined || stated === null) {
+		return { available, applicableNow: available };
+	}
+	const applicableNow = toResetCreditCount(stated);
+	if (applicableNow === null || applicableNow > available) return null;
+	return { available, applicableNow };
+}
+
+export function formatResetCredits(counts: ResetCreditCounts): string {
+	return counts.applicableNow === counts.available
+		? `${counts.available} banked`
+		: `${counts.available} banked (${counts.applicableNow} applicable now)`;
 }
 
 export function formatAdditionalUsageLimitName(
@@ -399,6 +462,7 @@ export function parseCodexUsagePayload(
 	return {
 		planType: source.plan_type ?? null,
 		credits: credits ?? null,
+		resetCredits: parseUsageResetCredits(source.rate_limit_reset_credits),
 		primary,
 		secondary,
 		codeReview,

--- a/lib/codex-usage.ts
+++ b/lib/codex-usage.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { extractAccountId } from "./accounts.js";
 import { extractAccountUserId } from "./auth/token-utils.js";
 import { getFetchTimeoutMs, loadPluginConfig } from "./config.js";
+import { normalizeResetCreditCount } from "./codex-reset.js";
 import { CODEX_BASE_URL, PLUGIN_NAME } from "./constants.js";
 import {
 	createDeactivatedWorkspaceError,
@@ -84,7 +85,8 @@ export type AdditionalUsageLimit = {
 
 export type ResetCreditCounts = {
 	available: number;
-	applicableNow: number;
+	/** `null` when the server stated a count this code cannot read. */
+	applicableNow: number | null;
 };
 
 export type CodexUsageSummary = {
@@ -247,13 +249,6 @@ export function formatUsageCredits(
 	return undefined;
 }
 
-function toResetCreditCount(value: unknown): number | null {
-	if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-		return null;
-	}
-	return Math.trunc(value);
-}
-
 /**
  * Read the redeemable rate-limit resets the usage response already carries.
  *
@@ -271,28 +266,40 @@ function toResetCreditCount(value: unknown): number | null {
  * `secondary_window` arrives on every single-window plan.
  *
  * A count the server did state and this code cannot read is a different thing,
- * and defaulting it would invent an answer. A negative, non-numeric or
- * larger-than-banked applicable count makes the whole reading unknown rather
- * than fully applicable, because over-reporting sends someone to redeem a
+ * and defaulting it would invent an answer. A negative, fractional,
+ * non-numeric or larger-than-banked applicable count therefore reports
+ * `applicableNow: null`, because over-reporting sends someone to redeem a
  * credit that is not there.
+ *
+ * Only `applicableNow` goes unknown, not the whole reading: the banked count
+ * is a separate field that arrived intact, and dropping it would print
+ * "Credits: 0" while a full reset waits to be redeemed - the exact failure
+ * this function exists to fix. `codex-reset` reads the same banked total from
+ * the list endpoint, so discarding it here would also make the two surfaces
+ * disagree about the same account in the same session.
  */
 export function parseUsageResetCredits(
 	source: UsageResetCredits | undefined,
 ): ResetCreditCounts | null {
 	if (typeof source !== "object" || source === null) return null;
-	const available = toResetCreditCount(source.available_count);
+	const available = normalizeResetCreditCount(source.available_count);
 	if (available === null) return null;
 
 	const stated = source.applicable_available_count;
 	if (stated === undefined || stated === null) {
 		return { available, applicableNow: available };
 	}
-	const applicableNow = toResetCreditCount(stated);
-	if (applicableNow === null || applicableNow > available) return null;
+	const applicableNow = normalizeResetCreditCount(stated);
+	if (applicableNow === null || applicableNow > available) {
+		return { available, applicableNow: null };
+	}
 	return { available, applicableNow };
 }
 
 export function formatResetCredits(counts: ResetCreditCounts): string {
+	if (counts.applicableNow === null) {
+		return `${counts.available} banked (applicable now unknown)`;
+	}
 	return counts.applicableNow === counts.available
 		? `${counts.available} banked`
 		: `${counts.available} banked (${counts.applicableNow} applicable now)`;

--- a/lib/tools/codex-limits.ts
+++ b/lib/tools/codex-limits.ts
@@ -9,6 +9,7 @@ import {
 	deduplicateUsageAccountIndices,
 	ensureCodexUsageAccessToken,
 	fetchCodexUsage,
+	formatResetCredits,
 	formatUsageLimitSummary,
 	formatUsageLimitTitle,
 	getUsageQuotaExhaustedResetAtMs,
@@ -243,6 +244,7 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 						sharesActiveCredential,
 						planType: usage.planType,
 						credits: usage.credits,
+						resetCredits: usage.resetCredits,
 						limits: usage.limits,
 					});
 
@@ -275,6 +277,11 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 								`  ${formatUiKeyValue(ui, "Credits", usage.credits, "muted")}`,
 							);
 						}
+						if (usage.resetCredits && usage.resetCredits.available > 0) {
+							lines.push(
+								`  ${formatUiKeyValue(ui, "Resets", formatResetCredits(usage.resetCredits), "muted")}`,
+							);
+						}
 					} else {
 						lines.push(`${displayLabel}${activeSuffix}:`);
 						for (const window of [usage.primary, usage.secondary]) {
@@ -299,6 +306,11 @@ export function createCodexLimitsTool(ctx: ToolContext): ToolDefinition {
 						}
 						if (usage.credits) {
 							lines.push(`  Credits: ${usage.credits}`);
+						}
+						if (usage.resetCredits && usage.resetCredits.available > 0) {
+							lines.push(
+								`  Resets: ${formatResetCredits(usage.resetCredits)}`,
+							);
 						}
 					}
 				} catch (error) {

--- a/scripts/install-oc-codex-multi-auth-core.js
+++ b/scripts/install-oc-codex-multi-auth-core.js
@@ -624,11 +624,13 @@ export async function runLimitsCommand(parsed, options = {}) {
 			}
 			entry.planType = usage.planType;
 			entry.credits = usage.credits;
-			entry.resetCredits = usage.resetCredits
-				? {
-						...usage.resetCredits,
-						summary: usageMod.formatResetCredits(usage.resetCredits),
-					}
+			// Raw counts stay in `resetCredits` and the rendered line lives in
+			// its own field: embedding the English summary inside the counts
+			// object would make `--json` consumers parse presentation text to
+			// reach a number that is already beside it.
+			entry.resetCredits = usage.resetCredits;
+			entry.resetCreditsSummary = usage.resetCredits
+				? usageMod.formatResetCredits(usage.resetCredits)
 				: null;
 			entry.limits = usage.limits;
 		} catch (error) {
@@ -682,7 +684,7 @@ function printLimitsResult(payload, json) {
 		if (account.planType) console.log(`  Plan: ${account.planType}`);
 		if (account.credits) console.log(`  Credits: ${account.credits}`);
 		if (account.resetCredits && account.resetCredits.available > 0) {
-			console.log(`  Resets: ${account.resetCredits.summary}`);
+			console.log(`  Resets: ${account.resetCreditsSummary}`);
 		}
 	}
 	if (payload.nextAction) console.log(`Next: ${payload.nextAction}`);

--- a/scripts/install-oc-codex-multi-auth-core.js
+++ b/scripts/install-oc-codex-multi-auth-core.js
@@ -624,6 +624,12 @@ export async function runLimitsCommand(parsed, options = {}) {
 			}
 			entry.planType = usage.planType;
 			entry.credits = usage.credits;
+			entry.resetCredits = usage.resetCredits
+				? {
+						...usage.resetCredits,
+						summary: usageMod.formatResetCredits(usage.resetCredits),
+					}
+				: null;
 			entry.limits = usage.limits;
 		} catch (error) {
 			// `ensureCodexUsageAccessToken` can surface a raw OAuth refresh
@@ -675,6 +681,9 @@ function printLimitsResult(payload, json) {
 		}
 		if (account.planType) console.log(`  Plan: ${account.planType}`);
 		if (account.credits) console.log(`  Credits: ${account.credits}`);
+		if (account.resetCredits && account.resetCredits.available > 0) {
+			console.log(`  Resets: ${account.resetCredits.summary}`);
+		}
 	}
 	if (payload.nextAction) console.log(`Next: ${payload.nextAction}`);
 }

--- a/test/codex-reset.test.ts
+++ b/test/codex-reset.test.ts
@@ -67,6 +67,24 @@ describe("parseCodexResetCredits", () => {
 		expect(summary.availableCount).toBe(2);
 	});
 
+	it("derives the available count when the server states an unreadable one", () => {
+		// `codex-limits` reads the same counter off the usage endpoint through
+		// the shared `normalizeResetCreditCount`, so both surfaces agree on
+		// what a sane count is. Only the fallback differs: this endpoint sends
+		// the credits themselves and can count them, and the usage endpoint
+		// does not.
+		const credits = [
+			{ id: "a", status: "available" },
+			{ id: "b", status: "available" },
+		];
+
+		expect(parseCodexResetCredits({ available_count: 1.7, credits }).availableCount).toBe(2);
+		expect(parseCodexResetCredits({ available_count: -1, credits }).availableCount).toBe(2);
+		expect(
+			parseCodexResetCredits({ available_count: Number.NaN, credits }).availableCount,
+		).toBe(2);
+	});
+
 	it("drops credits without an id, since they cannot be redeemed", () => {
 		const summary = parseCodexResetCredits({
 			credits: [{ status: "available" }, { id: "  ", status: "available" }],

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -450,6 +450,100 @@ describe("disabled usage windows (issue #194)", () => {
 		expect(hasUsageWindow(usage.primary)).toBe(true);
 		expect(usage.limits[0]).toMatchObject({ name: "quota limit", leftPercent: 90 });
 	});
+
+	it("reports the banked resets the usage response already carries", () => {
+		const usage = parseCodexUsagePayload({
+			plan_type: "pro",
+			rate_limit: {
+				primary_window: { used_percent: 100, limit_window_seconds: 604800 },
+			},
+			rate_limit_reset_credits: {
+				available_count: 2,
+				applicable_available_count: 2,
+			},
+		});
+
+		expect(usage.resetCredits).toEqual({ available: 2, applicableNow: 2 });
+	});
+
+	it("separates banked resets from a spent purchase balance", () => {
+		// The two are different currencies and the account below holds both
+		// readings at once: no purchase balance, two redeemable resets. Reporting
+		// only `credits` reads as "you have nothing" while a reset is waiting.
+		const usage = parseCodexUsagePayload({
+			credits: { has_credits: false, balance: "0" },
+			rate_limit_reset_credits: { available_count: 2, applicable_available_count: 2 },
+		});
+
+		expect(usage.credits).toBe("0");
+		expect(usage.resetCredits).toEqual({ available: 2, applicableNow: 2 });
+	});
+
+	it("distinguishes a banked reset that does not apply yet", () => {
+		// An account inside its quota reports the credit as banked but not
+		// applicable, because there is no exhausted window for it to clear.
+		const usage = parseCodexUsagePayload({
+			rate_limit_reset_credits: { available_count: 1, applicable_available_count: 0 },
+		});
+
+		expect(usage.resetCredits).toEqual({ available: 1, applicableNow: 0 });
+	});
+
+	it("treats absent or malformed reset-credit data as unknown", () => {
+		expect(parseCodexUsagePayload({}).resetCredits).toBeNull();
+		expect(parseCodexUsagePayload({ rate_limit_reset_credits: null }).resetCredits).toBeNull();
+		expect(
+			parseCodexUsagePayload({
+				rate_limit_reset_credits: "two" as unknown as never,
+			}).resetCredits,
+		).toBeNull();
+		expect(
+			parseCodexUsagePayload({
+				rate_limit_reset_credits: { available_count: -1 },
+			}).resetCredits,
+		).toBeNull();
+	});
+
+	it("defaults an omitted applicable count to the banked count", () => {
+		// Older responses carry only `available_count`. Treating the missing
+		// field as zero would report every banked reset as unusable.
+		const usage = parseCodexUsagePayload({
+			rate_limit_reset_credits: { available_count: 3 },
+		});
+
+		expect(usage.resetCredits).toEqual({ available: 3, applicableNow: 3 });
+	});
+
+	it("reads a null applicable count as the omission it is", () => {
+		// JSON's way of saying "not provided", and this endpoint does send it -
+		// `secondary_window` arrives as a literal null on single-window plans.
+		// A fix that defaults only on `undefined` would treat it as a stated
+		// value, find it unreadable, and hide three real banked resets.
+		const usage = parseCodexUsagePayload({
+			rate_limit_reset_credits: {
+				available_count: 3,
+				applicable_available_count: null,
+			},
+		});
+
+		expect(usage.resetCredits).toEqual({ available: 3, applicableNow: 3 });
+	});
+
+	it("reports nothing when the applicable count is stated but cannot be true", () => {
+		const unreadable = (applicable: unknown) =>
+			parseCodexUsagePayload({
+				rate_limit_reset_credits: {
+					available_count: 2,
+					applicable_available_count: applicable as number,
+				},
+			}).resetCredits;
+
+		expect(unreadable(-1)).toBeNull();
+		expect(unreadable(Number.NaN)).toBeNull();
+		expect(unreadable("1")).toBeNull();
+		// A subset cannot outnumber the set it is drawn from.
+		expect(unreadable(3)).toBeNull();
+	});
 });
 
 describe("Codex usage endpoint", () => {

--- a/test/codex-usage.test.ts
+++ b/test/codex-usage.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import {
 	deduplicateUsageAccountIndices,
 	fetchCodexUsage,
+	formatResetCredits,
 	formatUsageLimitSummary,
 	formatUsageReset,
 	getUsageQuotaExhaustedResetAtMs,
@@ -529,7 +530,11 @@ describe("disabled usage windows (issue #194)", () => {
 		expect(usage.resetCredits).toEqual({ available: 3, applicableNow: 3 });
 	});
 
-	it("reports nothing when the applicable count is stated but cannot be true", () => {
+	it("keeps the banked count when the applicable count cannot be true", () => {
+		// The two counts are separate fields. An unreadable applicable count
+		// says nothing about the banked total that arrived beside it, and
+		// dropping both would print "Credits: 0" over two real resets while
+		// `codex-reset` reports them from the list endpoint.
 		const unreadable = (applicable: unknown) =>
 			parseCodexUsagePayload({
 				rate_limit_reset_credits: {
@@ -538,11 +543,34 @@ describe("disabled usage windows (issue #194)", () => {
 				},
 			}).resetCredits;
 
-		expect(unreadable(-1)).toBeNull();
-		expect(unreadable(Number.NaN)).toBeNull();
-		expect(unreadable("1")).toBeNull();
+		expect(unreadable(-1)).toEqual({ available: 2, applicableNow: null });
+		expect(unreadable(Number.NaN)).toEqual({ available: 2, applicableNow: null });
+		expect(unreadable("1")).toEqual({ available: 2, applicableNow: null });
 		// A subset cannot outnumber the set it is drawn from.
-		expect(unreadable(3)).toBeNull();
+		expect(unreadable(3)).toEqual({ available: 2, applicableNow: null });
+		// A count is a whole number of resets: truncating 1.9 to 1 would hide
+		// a malformed payload behind a plausible-looking answer.
+		expect(unreadable(1.9)).toEqual({ available: 2, applicableNow: null });
+	});
+
+	it("rejects a fractional banked count outright", () => {
+		// No second field to fall back on here, so an unreadable banked count
+		// makes the whole reading unknown rather than a truncated guess.
+		expect(
+			parseCodexUsagePayload({
+				rate_limit_reset_credits: { available_count: 0.9 },
+			}).resetCredits,
+		).toBeNull();
+	});
+
+	it("says which banked resets can be redeemed right now", () => {
+		expect(formatResetCredits({ available: 2, applicableNow: 2 })).toBe("2 banked");
+		expect(formatResetCredits({ available: 2, applicableNow: 1 })).toBe(
+			"2 banked (1 applicable now)",
+		);
+		expect(formatResetCredits({ available: 2, applicableNow: null })).toBe(
+			"2 banked (applicable now unknown)",
+		);
 	});
 });
 


### PR DESCRIPTION
## Summary

- What changed?

  `parseCodexUsagePayload` now reads `rate_limit_reset_credits` out of the
  `/wham/usage` response it already fetches, and `codex-limits` prints a
  `Resets:` line for any account that has banked reset credits. The
  standalone CLI gets it for free, since it loads the same compiled parser.

  ```
  - [0] Account 1 (ofer....net)
    Weekly limit: 0% left (resets 22:20 on Sep 06)
    Plan: pro
    Credits: 0
    Resets: 2 banked
  - [4] Account 5 (enri....com)
    Weekly limit: 68% left (resets 12:46 on Sep 12)
    Plan: pro
    Credits: 0
    Resets: 1 banked (0 applicable now)
  ```

- Why is this needed?

  `Credits` is the purchase balance. Rate-limit reset credits are a
  different currency, and an account routinely holds both readings at once.
  Account 1 above is the real case: weekly window fully spent, balance `0`,
  and two banked "Full reset" credits sitting unused. `codex-limits` printed
  only `Credits: 0` for it, which reads as "you have nothing" at exactly the
  moment a reset would have unblocked the account.

  The counts were already in hand: they arrive in the same usage response
  the tool fetches, and the parser dropped the field. Surfacing them costs
  no extra request. `codex-reset` can already show them, but only by calling
  a second endpoint, and only if you already suspect there is something to
  look for.

  Two counts are reported because they answer different questions.
  `available_count` is what the account has banked; `applicable_available_count`
  is the subset redeemable right now, which is smaller whenever no window is
  exhausted yet. Account 5 above shows `1 banked (0 applicable now)` rather
  than implying a reset it cannot currently spend. A response that omits the
  applicable count predates the field rather than reporting zero, so it falls
  back to the banked count; defaulting to zero would report every banked
  reset as unusable. Accounts with no banked resets render exactly as before.

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`
- [ ] Not applicable

5 new cases in `test/codex-usage.test.ts` cover: the counts being read, a
banked reset alongside a spent purchase balance, banked-but-not-applicable,
absent/malformed/negative payloads normalizing to `null`, and an omitted
applicable count defaulting to the banked count. Each was watched fail
before the implementation existed.

Also exercised against live accounts through the standalone CLI, which is
where the output above comes from.

## Compliance Confirmation

- [x] This change stays within the repository scope and OpenAI Terms of Service expectations.
- [x] This change uses official authentication flows only and does not add bypass, scraping, or credential-sharing behavior.
- [x] I updated tests and documentation when the change affected users, maintainers, or repository behavior.

## Notes

- Linked issue: none
- Follow-up work or rollout notes:

  Purely additive: 137 insertions, 0 deletions, no existing line touched.

  One caveat on my local test run, for transparency. On a heavily loaded
  box (20 cores at load ~85) `test/index-retry.test.ts`, `test/index.test.ts`
  and `test/standalone-cli.test.ts` hit vitest's 5s timeout. Re-running
  exactly those three with `--no-file-parallelism` passes 279/279. The set of
  failing case names differs between runs, and the same three files flake the
  same way on a tree without this change, so it is host saturation rather
  than anything here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Limits information now displays reset-credit details, including available and currently applicable counts.
  * Reset-credit data is included in structured account output.
  * When the applicable count is unknown, the available banked count remains visible with a clear indicator.

* **Bug Fixes**
  * Improved handling of missing, malformed, negative, fractional, and oversized reset-credit values.
  * Invalid applicable counts no longer discard otherwise valid available-credit information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

**note:** greptile review for oc-chatgpt-multi-auth. cite files like `lib/foo.ts:123`. confirm regression tests + windows concurrency/token redaction coverage.
---


<h3>Greptile Summary</h3>

this pr surfaces banked rate-limit reset credits from the existing usage response across the in-session limits tool and standalone cli.
- shares strict reset-count normalization between usage and reset endpoints.
- distinguishes banked credits from credits applicable now.
- keeps malformed applicable counts explicitly unknown.
- adds parser coverage, but standalone json and text rendering still lack vitest coverage.

<h3>Confidence Score: 5/5</h3>

the implementation appears safe to merge, with non-blocking missing standalone cli coverage for the new output contract.

parsing and rendering preserve structured banked counts, avoid inventing malformed applicable counts, and introduce no windows filesystem, token safety, or concurrency regression. the remaining concern is limited to missing vitest protection for standalone json and text output.

**Files Needing Attention:** scripts/install-oc-codex-multi-auth-core.js

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| lib/codex-reset.ts | adds shared integer-only reset-count normalization and preserves list-derived fallback behavior. |
| lib/codex-usage.ts | parses and formats banked and currently applicable reset-credit counts. |
| lib/tools/codex-limits.ts | includes reset-credit data in structured results and renders nonzero balances. |
| scripts/install-oc-codex-multi-auth-core.js | adds standalone json and text reset-credit output without direct cli vitest coverage. |
| test/codex-usage.test.ts | covers valid, omitted, malformed, fractional, and inconsistent reset-credit payloads. |
| test/codex-reset.test.ts | verifies malformed reported totals fall back to actionable credit entries. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A["authenticated /wham/usage response"] --> B["parseCodexUsagePayload"]
  B --> C["normalize reset-credit counts"]
  C --> D["codex-limits tool"]
  C --> E["standalone limits command"]
  D --> F["text or structured output"]
  E --> G["text or json output"]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/install-oc-codex-multi-auth-core.js:631-634
**standalone output lacks coverage**

the standalone limits output now exposes `resetCredits` and `resetCreditsSummary` in json, while text rendering depends on the new summary field. existing vitest assertions cover neither this json contract nor the new `resets:` line, so packaging or serialization regressions could silently break this user-facing feature. add standalone cli coverage for both output modes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(limits): keep the banked count when ..."](https://github.com/ndycode/oc-codex-multi-auth/commit/49bc7d2c4d6fc25a805538d5a9c0e0dae8aa0693) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60857499)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Command and terminal experience](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/command-experience.md)
- Knowledge Base — [CLI command workflows](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/cli-command-workflows.md)
- Knowledge Base — [Quota monitoring and notifications](https://app.greptile.com/zeian/-/custom-context/knowledge-base/ndycode/oc-codex-multi-auth/-/docs/quota-monitoring-and-notifications.md)
</details>


<!-- /greptile_comment -->